### PR TITLE
Fix inheritance sources model attributes

### DIFF
--- a/docs/data-sources/dhcp_fixed_addresses.md
+++ b/docs/data-sources/dhcp_fixed_addresses.md
@@ -111,17 +111,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -129,7 +129,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -146,11 +146,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -160,11 +160,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -174,11 +174,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/data-sources/dhcp_servers.md
+++ b/docs/data-sources/dhcp_servers.md
@@ -222,56 +222,50 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_block.value`
 
-Optional:
+Read-Only:
 
 - `client_principal` (String) The Kerberos principal name. It uses the typical Kerberos notation: <SERVICE-NAME>/<server-domain-name>@<REALM>.  Defaults to empty.
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_enabled` (Boolean) Indicates if DDNS is enabled.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
-- `ddns_zones` (Attributes List) The list of DDNS zones. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones))
+- `ddns_zones` (Attributes List) The list of DDNS zones. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones))
 - `gss_tsig_fallback` (Boolean) The behavior when GSS-TSIG should be used (a matching external DNS server is configured) but no GSS-TSIG key is available. If configured to _false_ (the default) this DNS server is skipped, if configured to _true_ the DNS server is ignored and the DNS update is sent with the configured DHCP-DDNS protection e.g. TSIG key or without any protection when none was configured.  Defaults to _false_.
 - `kerberos_kdc` (String) Address of Kerberos Key Distribution Center.  Defaults to empty.
-- `kerberos_keys` (Attributes List) _kerberos_keys_ contains a list of keys for GSS-TSIG signed dynamic updates.  Defaults to empty. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--display_name--kerberos_keys))
+- `kerberos_keys` (Attributes List) _kerberos_keys_ contains a list of keys for GSS-TSIG signed dynamic updates.  Defaults to empty. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value--kerberos_keys))
 - `kerberos_rekey_interval` (Number) Time interval (in seconds) the keys for each configured external DNS server are checked for rekeying, i.e. a new key is created to replace the current usable one when its age is greater than the rekey_interval value.  Defaults to 120 seconds.
 - `kerberos_retry_interval` (Number) Time interval (in seconds) to retry to create a key if any error occurred previously for any configured external DNS server.  Defaults to 30 seconds.
 - `kerberos_tkey_lifetime` (Number) Lifetime (in seconds) of GSS-TSIG keys in the TKEY protocol.  Defaults to 160 seconds.
 - `kerberos_tkey_protocol` (String) Determines which protocol is used to establish the security context with the external DNS servers, TCP or UDP.  Defaults to _tcp_.
 - `server_principal` (String) The Kerberos principal name of the external DNS server that will receive updates.  Defaults to empty.
 
-<a id="nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones"></a>
-### Nested Schema for `results.inheritance_sources.ddns_block.display_name.ddns_zones`
-
-Required:
-
-- `zone` (String) The resource identifier.
-
-Optional:
-
-- `fqdn` (String) Zone FQDN.  If _zone_ is defined, the _fqdn_ field must be empty.
-- `gss_tsig_enabled` (Boolean) _gss_tsig_enabled_ enables/disables GSS-TSIG signed dynamic updates.  Defaults to _false_.
-- `nameservers` (Attributes List) The Nameservers in the zone.  Each nameserver IP should be unique across the list of nameservers. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones--nameservers))
-- `tsig_enabled` (Boolean) Indicates if TSIG key should be used for the update.  Defaults to _false_.
-- `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones--tsig_key))
+<a id="nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones"></a>
+### Nested Schema for `results.inheritance_sources.ddns_block.value.ddns_zones`
 
 Read-Only:
 
+- `fqdn` (String) Zone FQDN.  If _zone_ is defined, the _fqdn_ field must be empty.
+- `gss_tsig_enabled` (Boolean) _gss_tsig_enabled_ enables/disables GSS-TSIG signed dynamic updates.  Defaults to _false_.
+- `nameservers` (Attributes List) The Nameservers in the zone.  Each nameserver IP should be unique across the list of nameservers. (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones--nameservers))
+- `tsig_enabled` (Boolean) Indicates if TSIG key should be used for the update.  Defaults to _false_.
+- `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones--tsig_key))
 - `view` (String) The resource identifier.
 - `view_name` (String) The name of the view.
+- `zone` (String) The resource identifier.
 
-<a id="nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones--nameservers"></a>
-### Nested Schema for `results.inheritance_sources.ddns_block.display_name.ddns_zones.view_name`
+<a id="nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones--nameservers"></a>
+### Nested Schema for `results.inheritance_sources.ddns_block.value.ddns_zones.zone`
 
-Optional:
+Read-Only:
 
 - `client_principal` (String) The Kerberos principal name. It uses the typical Kerberos notation: <SERVICE-NAME>/<server-domain-name>@<REALM>.  Defaults to empty.
 - `gss_tsig_fallback` (Boolean) The behavior when GSS-TSIG should be used (a matching external DNS server is configured) but no GSS-TSIG key is available. If configured to _false_ (the default) this DNS server is skipped, if configured to _true_ the DNS server is ignored and the DNS update is sent with the configured DHCP-DDNS protection e.g. TSIG key or without any protection when none was configured.  Defaults to _false_.
@@ -283,37 +277,28 @@ Optional:
 - `server_principal` (String) The Kerberos principal name of this DNS server that will receive updates.  Defaults to empty.
 
 
-<a id="nestedatt--results--inheritance_sources--ddns_block--display_name--ddns_zones--tsig_key"></a>
-### Nested Schema for `results.inheritance_sources.ddns_block.display_name.ddns_zones.view_name`
-
-Required:
-
-- `key` (String) The resource identifier.
-
-Optional:
-
-- `algorithm` (String) TSIG key algorithm.  Valid values are:  * _hmac_sha256_  * _hmac_sha1_  * _hmac_sha224_  * _hmac_sha384_  * _hmac_sha512_
-- `comment` (String) The description for the TSIG key. May contain 0 to 1024 characters. Can include UTF-8.
-- `name` (String) The TSIG key name, FQDN.
-- `secret` (String) The TSIG key secret, base64 string.
+<a id="nestedatt--results--inheritance_sources--ddns_block--value--ddns_zones--tsig_key"></a>
+### Nested Schema for `results.inheritance_sources.ddns_block.value.ddns_zones.zone`
 
 Read-Only:
 
-- `protocol_name` (String) The TSIG key name in punycode.
-
-
-
-<a id="nestedatt--results--inheritance_sources--ddns_block--display_name--kerberos_keys"></a>
-### Nested Schema for `results.inheritance_sources.ddns_block.display_name.kerberos_keys`
-
-Required:
-
+- `algorithm` (String) TSIG key algorithm.  Valid values are:  * _hmac_sha256_  * _hmac_sha1_  * _hmac_sha224_  * _hmac_sha384_  * _hmac_sha512_
+- `comment` (String) The description for the TSIG key. May contain 0 to 1024 characters. Can include UTF-8.
 - `key` (String) The resource identifier.
+- `name` (String) The TSIG key name, FQDN.
+- `protocol_name` (String) The TSIG key name in punycode.
+- `secret` (String) The TSIG key secret, base64 string.
+
+
+
+<a id="nestedatt--results--inheritance_sources--ddns_block--value--kerberos_keys"></a>
+### Nested Schema for `results.inheritance_sources.ddns_block.value.kerberos_keys`
 
 Read-Only:
 
 - `algorithm` (String) Encryption algorithm of the key in accordance with RFC 3961.
 - `domain` (String) Kerberos realm of the principal.
+- `key` (String) The resource identifier.
 - `principal` (String) Kerberos principal associated with key.
 - `uploaded_at` (String) Upload time for the key.
 - `version` (Number) The version number (KVNO) of the key.
@@ -327,11 +312,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -341,11 +326,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -355,17 +340,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_hostname_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_hostname_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -378,11 +363,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -392,11 +377,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -406,11 +391,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -436,11 +421,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -450,11 +435,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -464,11 +449,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -478,11 +463,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -492,12 +477,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -506,12 +491,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -520,11 +505,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -534,17 +519,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_config.lease_time_v6.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -557,11 +542,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -571,11 +556,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -594,17 +579,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -612,7 +597,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -637,17 +622,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options_v6--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options_v6.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -655,7 +640,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options_v6--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options_v6.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -672,11 +657,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -686,11 +671,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -700,11 +685,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -714,17 +699,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--results--inheritance_sources--hostname_rewrite_block--value"></a>
-### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.display_name`
+### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.
@@ -738,12 +723,12 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (String) The resource identifier.
 
 
 

--- a/docs/data-sources/dns_a_records.md
+++ b/docs/data-sources/dns_a_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_aaaa_records.md
+++ b/docs/data-sources/dns_aaaa_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_auth_zones.md
+++ b/docs/data-sources/dns_auth_zones.md
@@ -175,11 +175,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -189,11 +189,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -203,38 +203,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -248,38 +242,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -293,38 +281,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -338,11 +320,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -366,11 +348,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -380,11 +362,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -394,24 +376,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--zone_authority--rname--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--zone_authority--rname--value))
 
 <a id="nestedatt--results--inheritance_sources--zone_authority--rname--value"></a>
 ### Nested Schema for `results.inheritance_sources.zone_authority.rname.value`
 
-Optional:
-
-- `mname` (String) Defaults to empty.
-- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
-
 Read-Only:
 
+- `mname` (String) Defaults to empty.
 - `protocol_mname` (String) Optional. Master name server in punycode.  Defaults to empty.
+- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
 
 
 
@@ -421,11 +400,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -435,11 +414,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -449,11 +428,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -463,11 +442,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -477,11 +456,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/data-sources/dns_caa_records.md
+++ b/docs/data-sources/dns_caa_records.md
@@ -116,9 +116,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_cname_records.md
+++ b/docs/data-sources/dns_cname_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_dname_records.md
+++ b/docs/data-sources/dns_dname_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_hosts.md
+++ b/docs/data-sources/dns_hosts.md
@@ -93,24 +93,21 @@ Optional:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--kerberos_keys--value))
 
 <a id="nestedatt--results--inheritance_sources--kerberos_keys--value"></a>
 ### Nested Schema for `results.inheritance_sources.kerberos_keys.value`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) Encryption algorithm of the key in accordance with RFC 3961.
 - `domain` (String) Kerberos realm of the principal.
+- `key` (String) The resource identifier.
 - `principal` (String) Kerberos principal associated with key.
 - `uploaded_at` (String) Upload time for the key.
 - `version` (Number) The version number (KVNO) of the key.

--- a/docs/data-sources/dns_https_records.md
+++ b/docs/data-sources/dns_https_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_mx_records.md
+++ b/docs/data-sources/dns_mx_records.md
@@ -104,9 +104,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_naptr_records.md
+++ b/docs/data-sources/dns_naptr_records.md
@@ -131,9 +131,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_ns_records.md
+++ b/docs/data-sources/dns_ns_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_ptr_records.md
+++ b/docs/data-sources/dns_ptr_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_records.md
+++ b/docs/data-sources/dns_records.md
@@ -142,9 +142,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_servers.md
+++ b/docs/data-sources/dns_servers.md
@@ -234,11 +234,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -248,31 +248,28 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value))
 
 <a id="nestedatt--results--inheritance_sources--custom_root_ns_block--value"></a>
-### Nested Schema for `results.inheritance_sources.custom_root_ns_block.display_name`
-
-Optional:
-
-- `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--display_name--custom_root_ns))
-- `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
-
-<a id="nestedatt--results--inheritance_sources--custom_root_ns_block--display_name--custom_root_ns"></a>
-### Nested Schema for `results.inheritance_sources.custom_root_ns_block.display_name.custom_root_ns`
-
-Required:
-
-- `address` (String) IPv4 address.
-- `fqdn` (String) FQDN.
+### Nested Schema for `results.inheritance_sources.custom_root_ns_block.value`
 
 Read-Only:
 
+- `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value--custom_root_ns))
+- `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
+
+<a id="nestedatt--results--inheritance_sources--custom_root_ns_block--value--custom_root_ns"></a>
+### Nested Schema for `results.inheritance_sources.custom_root_ns_block.value.custom_root_ns`
+
+Read-Only:
+
+- `address` (String) IPv4 address.
+- `fqdn` (String) FQDN.
 - `protocol_fqdn` (String) FQDN in punycode.
 
 
@@ -284,39 +281,33 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value))
 
 <a id="nestedatt--results--inheritance_sources--dnssec_validation_block--value"></a>
-### Nested Schema for `results.inheritance_sources.dnssec_validation_block.display_name`
-
-Optional:
-
-- `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
-- `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
-- `dnssec_trust_anchors` (Attributes List) Optional. Field config for _dnssec_trust_anchors_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--display_name--dnssec_trust_anchors))
-- `dnssec_validate_expiry` (Boolean) Optional. Field config for _dnssec_validate_expiry_ field.
-
-<a id="nestedatt--results--inheritance_sources--dnssec_validation_block--display_name--dnssec_trust_anchors"></a>
-### Nested Schema for `results.inheritance_sources.dnssec_validation_block.display_name.dnssec_trust_anchors`
-
-Required:
-
-- `algorithm` (Number)
-- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
-- `zone` (String) Zone FQDN.
-
-Optional:
-
-- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+### Nested Schema for `results.inheritance_sources.dnssec_validation_block.value`
 
 Read-Only:
 
+- `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
+- `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
+- `dnssec_trust_anchors` (Attributes List) Optional. Field config for _dnssec_trust_anchors_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors))
+- `dnssec_validate_expiry` (Boolean) Optional. Field config for _dnssec_validate_expiry_ field.
+
+<a id="nestedatt--results--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors"></a>
+### Nested Schema for `results.inheritance_sources.dnssec_validation_block.value.dnssec_trust_anchors`
+
+Read-Only:
+
+- `algorithm` (Number)
 - `protocol_zone` (String) Zone FQDN in punycode.
+- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
+- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+- `zone` (String) Zone FQDN.
 
 
 
@@ -327,34 +318,31 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ecs_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ecs_block.display_name`
+### Nested Schema for `results.inheritance_sources.ecs_block.value`
 
-Optional:
+Read-Only:
 
 - `ecs_enabled` (Boolean) Optional. Field config for _ecs_enabled_ field.
 - `ecs_forwarding` (Boolean) Optional. Field config for _ecs_forwarding_ field.
 - `ecs_prefix_v4` (Number) Optional. Field config for _ecs_prefix_v4_ field.
 - `ecs_prefix_v6` (Number) Optional. Field config for _ecs_prefix_v6_ field.
-- `ecs_zones` (Attributes List) Optional. Field config for _ecs_zones_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--display_name--ecs_zones))
+- `ecs_zones` (Attributes List) Optional. Field config for _ecs_zones_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value--ecs_zones))
 
-<a id="nestedatt--results--inheritance_sources--ecs_block--display_name--ecs_zones"></a>
-### Nested Schema for `results.inheritance_sources.ecs_block.display_name.ecs_zones`
-
-Required:
-
-- `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
-- `fqdn` (String) Zone FQDN.
+<a id="nestedatt--results--inheritance_sources--ecs_block--value--ecs_zones"></a>
+### Nested Schema for `results.inheritance_sources.ecs_block.value.ecs_zones`
 
 Read-Only:
 
+- `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
+- `fqdn` (String) Zone FQDN.
 - `protocol_fqdn` (String) Zone FQDN in punycode.
 
 
@@ -366,38 +354,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--filter_aaaa_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--filter_aaaa_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.filter_aaaa_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--filter_aaaa_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--filter_aaaa_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.filter_aaaa_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -411,11 +393,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -425,32 +407,29 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value))
 
 <a id="nestedatt--results--inheritance_sources--forwarders_block--value"></a>
-### Nested Schema for `results.inheritance_sources.forwarders_block.display_name`
-
-Optional:
-
-- `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--display_name--forwarders))
-- `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
-- `use_root_forwarders_for_local_resolution_with_b1td` (Boolean) Optional. Field config for _use_root_forwarders_for_local_resolution_with_b1td_ field.
-
-<a id="nestedatt--results--inheritance_sources--forwarders_block--display_name--forwarders"></a>
-### Nested Schema for `results.inheritance_sources.forwarders_block.display_name.forwarders`
-
-Required:
-
-- `address` (String) Server IP address.
-- `fqdn` (String) Server FQDN.
+### Nested Schema for `results.inheritance_sources.forwarders_block.value`
 
 Read-Only:
 
+- `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value--forwarders))
+- `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
+- `use_root_forwarders_for_local_resolution_with_b1td` (Boolean) Optional. Field config for _use_root_forwarders_for_local_resolution_with_b1td_ field.
+
+<a id="nestedatt--results--inheritance_sources--forwarders_block--value--forwarders"></a>
+### Nested Schema for `results.inheritance_sources.forwarders_block.value.forwarders`
+
+Read-Only:
+
+- `address` (String) Server IP address.
+- `fqdn` (String) Server FQDN.
 - `protocol_fqdn` (String) Server FQDN in punycode.
 
 
@@ -462,11 +441,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -476,24 +455,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--kerberos_keys--value))
 
 <a id="nestedatt--results--inheritance_sources--kerberos_keys--value"></a>
 ### Nested Schema for `results.inheritance_sources.kerberos_keys.value`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) Encryption algorithm of the key in accordance with RFC 3961.
 - `domain` (String) Kerberos realm of the principal.
+- `key` (String) The resource identifier.
 - `principal` (String) Kerberos principal associated with key.
 - `uploaded_at` (String) Upload time for the key.
 - `version` (Number) The version number (KVNO) of the key.
@@ -506,11 +482,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -520,11 +496,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -534,11 +510,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -548,11 +524,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -562,11 +538,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -576,11 +552,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -590,11 +566,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -604,38 +580,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -649,11 +619,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -663,38 +633,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--recursion_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--recursion_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.recursion_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--recursion_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--recursion_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.recursion_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -708,11 +672,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -722,11 +686,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -736,11 +700,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -750,11 +714,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -764,11 +728,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -778,23 +742,20 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--sort_list--value))
 
 <a id="nestedatt--results--inheritance_sources--sort_list--value"></a>
 ### Nested Schema for `results.inheritance_sources.sort_list.value`
 
-Required:
-
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
-
-Optional:
+Read-Only:
 
 - `acl` (String) The resource identifier.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
 - `prioritized_networks` (List of String) Optional. The prioritized networks. If empty, the value of _source_ or networks from _acl_ is used.
 - `source` (String) Must be empty if _element_ is not _ip_.
 
@@ -806,11 +767,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -820,38 +781,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -865,38 +820,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -910,11 +859,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 

--- a/docs/data-sources/dns_srv_records.md
+++ b/docs/data-sources/dns_srv_records.md
@@ -115,9 +115,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_svcb_records.md
+++ b/docs/data-sources/dns_svcb_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_txt_records.md
+++ b/docs/data-sources/dns_txt_records.md
@@ -103,9 +103,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/data-sources/dns_views.md
+++ b/docs/data-sources/dns_views.md
@@ -237,11 +237,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -251,31 +251,28 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value))
 
 <a id="nestedatt--results--inheritance_sources--custom_root_ns_block--value"></a>
-### Nested Schema for `results.inheritance_sources.custom_root_ns_block.display_name`
-
-Optional:
-
-- `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--display_name--custom_root_ns))
-- `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
-
-<a id="nestedatt--results--inheritance_sources--custom_root_ns_block--display_name--custom_root_ns"></a>
-### Nested Schema for `results.inheritance_sources.custom_root_ns_block.display_name.custom_root_ns`
-
-Required:
-
-- `address` (String) IPv4 address.
-- `fqdn` (String) FQDN.
+### Nested Schema for `results.inheritance_sources.custom_root_ns_block.value`
 
 Read-Only:
 
+- `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--custom_root_ns_block--value--custom_root_ns))
+- `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
+
+<a id="nestedatt--results--inheritance_sources--custom_root_ns_block--value--custom_root_ns"></a>
+### Nested Schema for `results.inheritance_sources.custom_root_ns_block.value.custom_root_ns`
+
+Read-Only:
+
+- `address` (String) IPv4 address.
+- `fqdn` (String) FQDN.
 - `protocol_fqdn` (String) FQDN in punycode.
 
 
@@ -287,39 +284,33 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value))
 
 <a id="nestedatt--results--inheritance_sources--dnssec_validation_block--value"></a>
-### Nested Schema for `results.inheritance_sources.dnssec_validation_block.display_name`
-
-Optional:
-
-- `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
-- `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
-- `dnssec_trust_anchors` (Attributes List) Optional. Field config for _dnssec_trust_anchors_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--display_name--dnssec_trust_anchors))
-- `dnssec_validate_expiry` (Boolean) Optional. Field config for _dnssec_validate_expiry_ field.
-
-<a id="nestedatt--results--inheritance_sources--dnssec_validation_block--display_name--dnssec_trust_anchors"></a>
-### Nested Schema for `results.inheritance_sources.dnssec_validation_block.display_name.dnssec_trust_anchors`
-
-Required:
-
-- `algorithm` (Number)
-- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
-- `zone` (String) Zone FQDN.
-
-Optional:
-
-- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+### Nested Schema for `results.inheritance_sources.dnssec_validation_block.value`
 
 Read-Only:
 
+- `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
+- `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
+- `dnssec_trust_anchors` (Attributes List) Optional. Field config for _dnssec_trust_anchors_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors))
+- `dnssec_validate_expiry` (Boolean) Optional. Field config for _dnssec_validate_expiry_ field.
+
+<a id="nestedatt--results--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors"></a>
+### Nested Schema for `results.inheritance_sources.dnssec_validation_block.value.dnssec_trust_anchors`
+
+Read-Only:
+
+- `algorithm` (Number)
 - `protocol_zone` (String) Zone FQDN in punycode.
+- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
+- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+- `zone` (String) Zone FQDN.
 
 
 
@@ -337,11 +328,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -352,34 +343,31 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ecs_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ecs_block.display_name`
+### Nested Schema for `results.inheritance_sources.ecs_block.value`
 
-Optional:
+Read-Only:
 
 - `ecs_enabled` (Boolean) Optional. Field config for _ecs_enabled_ field.
 - `ecs_forwarding` (Boolean) Optional. Field config for _ecs_forwarding_ field.
 - `ecs_prefix_v4` (Number) Optional. Field config for _ecs_prefix_v4_ field.
 - `ecs_prefix_v6` (Number) Optional. Field config for _ecs_prefix_v6_ field.
-- `ecs_zones` (Attributes List) Optional. Field config for _ecs_zones_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--display_name--ecs_zones))
+- `ecs_zones` (Attributes List) Optional. Field config for _ecs_zones_ field. (see [below for nested schema](#nestedatt--results--inheritance_sources--ecs_block--value--ecs_zones))
 
-<a id="nestedatt--results--inheritance_sources--ecs_block--display_name--ecs_zones"></a>
-### Nested Schema for `results.inheritance_sources.ecs_block.display_name.ecs_zones`
-
-Required:
-
-- `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
-- `fqdn` (String) Zone FQDN.
+<a id="nestedatt--results--inheritance_sources--ecs_block--value--ecs_zones"></a>
+### Nested Schema for `results.inheritance_sources.ecs_block.value.ecs_zones`
 
 Read-Only:
 
+- `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
+- `fqdn` (String) Zone FQDN.
 - `protocol_fqdn` (String) Zone FQDN in punycode.
 
 
@@ -391,11 +379,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -405,38 +393,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--filter_aaaa_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--filter_aaaa_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.filter_aaaa_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--filter_aaaa_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--filter_aaaa_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.filter_aaaa_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -450,11 +432,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -464,32 +446,29 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value))
 
 <a id="nestedatt--results--inheritance_sources--forwarders_block--value"></a>
-### Nested Schema for `results.inheritance_sources.forwarders_block.display_name`
-
-Optional:
-
-- `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--display_name--forwarders))
-- `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
-- `use_root_forwarders_for_local_resolution_with_b1td` (Boolean) Optional. Field config for _use_root_forwarders_for_local_resolution_with_b1td_ field.
-
-<a id="nestedatt--results--inheritance_sources--forwarders_block--display_name--forwarders"></a>
-### Nested Schema for `results.inheritance_sources.forwarders_block.display_name.forwarders`
-
-Required:
-
-- `address` (String) Server IP address.
-- `fqdn` (String) Server FQDN.
+### Nested Schema for `results.inheritance_sources.forwarders_block.value`
 
 Read-Only:
 
+- `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--results--inheritance_sources--forwarders_block--value--forwarders))
+- `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
+- `use_root_forwarders_for_local_resolution_with_b1td` (Boolean) Optional. Field config for _use_root_forwarders_for_local_resolution_with_b1td_ field.
+
+<a id="nestedatt--results--inheritance_sources--forwarders_block--value--forwarders"></a>
+### Nested Schema for `results.inheritance_sources.forwarders_block.value.forwarders`
+
+Read-Only:
+
+- `address` (String) Server IP address.
+- `fqdn` (String) Server FQDN.
 - `protocol_fqdn` (String) Server FQDN in punycode.
 
 
@@ -501,11 +480,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -515,11 +494,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -529,11 +508,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -543,11 +522,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -557,11 +536,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -571,11 +550,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -585,11 +564,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -599,11 +578,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -613,38 +592,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -658,38 +631,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--recursion_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--recursion_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.recursion_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--recursion_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--recursion_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.recursion_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -703,11 +670,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -717,23 +684,20 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--sort_list--value))
 
 <a id="nestedatt--results--inheritance_sources--sort_list--value"></a>
 ### Nested Schema for `results.inheritance_sources.sort_list.value`
 
-Required:
-
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
-
-Optional:
+Read-Only:
 
 - `acl` (String) The resource identifier.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
 - `prioritized_networks` (List of String) Optional. The prioritized networks. If empty, the value of _source_ or networks from _acl_ is used.
 - `source` (String) Must be empty if _element_ is not _ip_.
 
@@ -745,11 +709,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -759,38 +723,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -804,38 +762,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--results--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `results.inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -849,11 +801,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -877,11 +829,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -891,11 +843,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -905,24 +857,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--zone_authority--rname--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--zone_authority--rname--value))
 
 <a id="nestedatt--results--inheritance_sources--zone_authority--rname--value"></a>
 ### Nested Schema for `results.inheritance_sources.zone_authority.rname.value`
 
-Optional:
-
-- `mname` (String) Defaults to empty.
-- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
-
 Read-Only:
 
+- `mname` (String) Defaults to empty.
 - `protocol_mname` (String) Optional. Master name server in punycode.  Defaults to empty.
+- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
 
 
 
@@ -932,11 +881,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -946,11 +895,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -960,11 +909,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -974,11 +923,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -988,11 +937,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/data-sources/ipam_address_blocks.md
+++ b/docs/data-sources/ipam_address_blocks.md
@@ -199,17 +199,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -223,17 +223,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -246,11 +246,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -260,11 +260,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -274,11 +274,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -288,11 +288,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -302,11 +302,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -317,11 +317,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -331,11 +331,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -345,11 +345,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -359,17 +359,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_hostname_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_hostname_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -382,11 +382,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -396,17 +396,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_update_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_update_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -419,11 +419,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -433,11 +433,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -463,11 +463,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -477,11 +477,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -491,11 +491,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -505,11 +505,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -519,12 +519,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -533,12 +533,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -547,11 +547,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -561,17 +561,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_config.lease_time_v6.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -584,11 +584,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -598,11 +598,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -621,17 +621,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -639,7 +639,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -656,11 +656,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -670,11 +670,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -684,11 +684,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -698,17 +698,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--results--inheritance_sources--hostname_rewrite_block--value"></a>
-### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.display_name`
+### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.

--- a/docs/data-sources/ipam_ip_spaces.md
+++ b/docs/data-sources/ipam_ip_spaces.md
@@ -193,17 +193,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -217,17 +217,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -240,11 +240,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -254,11 +254,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -268,11 +268,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -282,11 +282,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -296,11 +296,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -311,11 +311,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -325,11 +325,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -339,11 +339,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -353,17 +353,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_hostname_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_hostname_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -376,11 +376,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -390,17 +390,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_update_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_update_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -413,11 +413,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -427,11 +427,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -457,11 +457,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -471,11 +471,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -485,11 +485,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -499,11 +499,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -513,12 +513,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -527,12 +527,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -541,11 +541,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -555,17 +555,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_config.lease_time_v6.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -578,11 +578,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -592,11 +592,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -615,17 +615,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -633,7 +633,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -658,17 +658,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options_v6--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options_v6.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options_v6--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -676,7 +676,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options_v6--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options_v6.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -693,11 +693,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -707,11 +707,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -721,11 +721,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -735,17 +735,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--results--inheritance_sources--hostname_rewrite_block--value"></a>
-### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.display_name`
+### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.
@@ -759,12 +759,12 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (String) The resource identifier.
 
 
 

--- a/docs/data-sources/ipam_ranges.md
+++ b/docs/data-sources/ipam_ranges.md
@@ -143,17 +143,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -161,7 +161,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.

--- a/docs/data-sources/ipam_subnets.md
+++ b/docs/data-sources/ipam_subnets.md
@@ -195,17 +195,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -219,17 +219,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--asm_config--min_unused--value))
 
 <a id="nestedatt--results--inheritance_sources--asm_config--min_unused--value"></a>
 ### Nested Schema for `results.inheritance_sources.asm_config.min_unused.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -242,11 +242,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -256,11 +256,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -270,11 +270,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -284,11 +284,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -298,11 +298,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -313,11 +313,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -327,11 +327,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -341,11 +341,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -355,17 +355,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_hostname_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_hostname_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -378,11 +378,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -392,17 +392,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--results--inheritance_sources--ddns_update_block--value"></a>
-### Nested Schema for `results.inheritance_sources.ddns_update_block.display_name`
+### Nested Schema for `results.inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -415,11 +415,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -429,11 +429,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -459,11 +459,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -473,11 +473,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -487,11 +487,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -501,11 +501,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -515,12 +515,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -529,12 +529,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -543,11 +543,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -557,17 +557,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_config--lease_time_v6--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_config.lease_time_v6.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -580,11 +580,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -594,11 +594,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -617,17 +617,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
 - `option` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
@@ -635,7 +635,7 @@ Optional:
 <a id="nestedatt--results--inheritance_sources--dhcp_options--value--value--option"></a>
 ### Nested Schema for `results.inheritance_sources.dhcp_options.value.value.overriding_group`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -652,11 +652,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -666,11 +666,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -680,11 +680,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -694,17 +694,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--results--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--results--inheritance_sources--hostname_rewrite_block--value"></a>
-### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.display_name`
+### Nested Schema for `results.inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.

--- a/docs/resources/dhcp_fixed_address.md
+++ b/docs/resources/dhcp_fixed_address.md
@@ -138,25 +138,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -173,11 +173,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -187,11 +187,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -201,11 +201,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/resources/dhcp_server.md
+++ b/docs/resources/dhcp_server.md
@@ -207,17 +207,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_block.value`
 
-Optional:
+Read-Only:
 
 - `client_principal` (String) The Kerberos principal name. It uses the typical Kerberos notation: <SERVICE-NAME>/<server-domain-name>@<REALM>.  Defaults to empty.
 - `ddns_domain` (String) The domain name for DDNS.
@@ -236,27 +236,21 @@ Optional:
 <a id="nestedatt--inheritance_sources--ddns_block--value--ddns_zones"></a>
 ### Nested Schema for `inheritance_sources.ddns_block.value.server_principal`
 
-Required:
-
-- `zone` (String) The resource identifier.
-
-Optional:
+Read-Only:
 
 - `fqdn` (String) Zone FQDN.  If _zone_ is defined, the _fqdn_ field must be empty.
 - `gss_tsig_enabled` (Boolean) _gss_tsig_enabled_ enables/disables GSS-TSIG signed dynamic updates.  Defaults to _false_.
 - `nameservers` (Attributes List) The Nameservers in the zone.  Each nameserver IP should be unique across the list of nameservers. (see [below for nested schema](#nestedatt--inheritance_sources--ddns_block--value--server_principal--nameservers))
 - `tsig_enabled` (Boolean) Indicates if TSIG key should be used for the update.  Defaults to _false_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_block--value--server_principal--tsig_key))
-
-Read-Only:
-
 - `view` (String) The resource identifier.
 - `view_name` (String) The name of the view.
+- `zone` (String) The resource identifier.
 
 <a id="nestedatt--inheritance_sources--ddns_block--value--server_principal--nameservers"></a>
 ### Nested Schema for `inheritance_sources.ddns_block.value.server_principal.nameservers`
 
-Optional:
+Read-Only:
 
 - `client_principal` (String) The Kerberos principal name. It uses the typical Kerberos notation: <SERVICE-NAME>/<server-domain-name>@<REALM>.  Defaults to empty.
 - `gss_tsig_fallback` (Boolean) The behavior when GSS-TSIG should be used (a matching external DNS server is configured) but no GSS-TSIG key is available. If configured to _false_ (the default) this DNS server is skipped, if configured to _true_ the DNS server is ignored and the DNS update is sent with the configured DHCP-DDNS protection e.g. TSIG key or without any protection when none was configured.  Defaults to _false_.
@@ -271,34 +265,25 @@ Optional:
 <a id="nestedatt--inheritance_sources--ddns_block--value--server_principal--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.ddns_block.value.server_principal.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
-Optional:
+Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Valid values are:  * _hmac_sha256_  * _hmac_sha1_  * _hmac_sha224_  * _hmac_sha384_  * _hmac_sha512_
 - `comment` (String) The description for the TSIG key. May contain 0 to 1024 characters. Can include UTF-8.
+- `key` (String) The resource identifier.
 - `name` (String) The TSIG key name, FQDN.
-- `secret` (String) The TSIG key secret, base64 string.
-
-Read-Only:
-
 - `protocol_name` (String) The TSIG key name in punycode.
+- `secret` (String) The TSIG key secret, base64 string.
 
 
 
 <a id="nestedatt--inheritance_sources--ddns_block--value--kerberos_keys"></a>
 ### Nested Schema for `inheritance_sources.ddns_block.value.server_principal`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) Encryption algorithm of the key in accordance with RFC 3961.
 - `domain` (String) Kerberos realm of the principal.
+- `key` (String) The resource identifier.
 - `principal` (String) Kerberos principal associated with key.
 - `uploaded_at` (String) Upload time for the key.
 - `version` (Number) The version number (KVNO) of the key.
@@ -312,11 +297,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -326,11 +311,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -340,17 +325,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_hostname_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -363,11 +348,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -377,11 +362,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -391,11 +376,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -421,11 +406,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -435,11 +420,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -449,11 +434,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -463,11 +448,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -477,12 +462,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -491,12 +476,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -505,11 +490,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -519,17 +504,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_config--ignore_list--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_list--value"></a>
 ### Nested Schema for `inheritance_sources.dhcp_config.ignore_list.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -542,11 +527,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -556,11 +541,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -579,25 +564,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -622,25 +607,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options_v6--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options_v6.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options_v6.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options_v6--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options_v6.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options_v6--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options_v6.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -657,11 +642,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -671,11 +656,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -685,11 +670,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -699,17 +684,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--inheritance_sources--hostname_rewrite_block--value"></a>
 ### Nested Schema for `inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.
@@ -723,12 +708,12 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (String) The resource identifier.
 
 
 

--- a/docs/resources/dns_a_record.md
+++ b/docs/resources/dns_a_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_aaaa_record.md
+++ b/docs/resources/dns_aaaa_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_auth_zone.md
+++ b/docs/resources/dns_auth_zone.md
@@ -156,11 +156,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -170,11 +170,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -184,38 +184,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -229,38 +223,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -274,38 +262,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -319,11 +301,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -347,11 +329,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -361,11 +343,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -375,24 +357,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--zone_authority--mname_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--zone_authority--mname_block--value))
 
 <a id="nestedatt--inheritance_sources--zone_authority--mname_block--value"></a>
-### Nested Schema for `inheritance_sources.zone_authority.mname_block.display_name`
-
-Optional:
-
-- `mname` (String) Defaults to empty.
-- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
+### Nested Schema for `inheritance_sources.zone_authority.mname_block.value`
 
 Read-Only:
 
+- `mname` (String) Defaults to empty.
 - `protocol_mname` (String) Optional. Master name server in punycode.  Defaults to empty.
+- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
 
 
 
@@ -402,11 +381,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -416,11 +395,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -430,11 +409,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -444,11 +423,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -458,11 +437,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/resources/dns_caa_record.md
+++ b/docs/resources/dns_caa_record.md
@@ -109,9 +109,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_cname_record.md
+++ b/docs/resources/dns_cname_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_dname_record.md
+++ b/docs/resources/dns_dname_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_https_record.md
+++ b/docs/resources/dns_https_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_mx_record.md
+++ b/docs/resources/dns_mx_record.md
@@ -96,9 +96,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_naptr_record.md
+++ b/docs/resources/dns_naptr_record.md
@@ -127,9 +127,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_ns_record.md
+++ b/docs/resources/dns_ns_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_ptr_record.md
+++ b/docs/resources/dns_ptr_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -134,9 +134,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_server.md
+++ b/docs/resources/dns_server.md
@@ -214,11 +214,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -228,17 +228,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value))
 
 <a id="nestedatt--inheritance_sources--custom_root_ns_block--value"></a>
 ### Nested Schema for `inheritance_sources.custom_root_ns_block.value`
 
-Optional:
+Read-Only:
 
 - `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value--custom_root_ns))
 - `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
@@ -246,13 +246,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--custom_root_ns_block--value--custom_root_ns"></a>
 ### Nested Schema for `inheritance_sources.custom_root_ns_block.value.custom_root_ns_enabled`
 
-Required:
+Read-Only:
 
 - `address` (String) IPv4 address.
 - `fqdn` (String) FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) FQDN in punycode.
 
 
@@ -264,17 +261,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dnssec_validation_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dnssec_validation_block--value))
 
 <a id="nestedatt--inheritance_sources--dnssec_validation_block--value"></a>
 ### Nested Schema for `inheritance_sources.dnssec_validation_block.value`
 
-Optional:
+Read-Only:
 
 - `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
 - `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
@@ -284,19 +281,13 @@ Optional:
 <a id="nestedatt--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors"></a>
 ### Nested Schema for `inheritance_sources.dnssec_validation_block.value.dnssec_validate_expiry`
 
-Required:
-
-- `algorithm` (Number)
-- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
-- `zone` (String) Zone FQDN.
-
-Optional:
-
-- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
-
 Read-Only:
 
+- `algorithm` (Number)
 - `protocol_zone` (String) Zone FQDN in punycode.
+- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
+- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+- `zone` (String) Zone FQDN.
 
 
 
@@ -307,17 +298,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ecs_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ecs_block--value))
 
 <a id="nestedatt--inheritance_sources--ecs_block--value"></a>
 ### Nested Schema for `inheritance_sources.ecs_block.value`
 
-Optional:
+Read-Only:
 
 - `ecs_enabled` (Boolean) Optional. Field config for _ecs_enabled_ field.
 - `ecs_forwarding` (Boolean) Optional. Field config for _ecs_forwarding_ field.
@@ -328,13 +319,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--ecs_block--value--ecs_zones"></a>
 ### Nested Schema for `inheritance_sources.ecs_block.value.ecs_zones`
 
-Required:
+Read-Only:
 
 - `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
 - `fqdn` (String) Zone FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) Zone FQDN in punycode.
 
 
@@ -346,38 +334,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--filter_aaaa_acl--value))
 
 <a id="nestedatt--inheritance_sources--filter_aaaa_acl--value"></a>
 ### Nested Schema for `inheritance_sources.filter_aaaa_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--filter_aaaa_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--filter_aaaa_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.filter_aaaa_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -391,11 +373,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -405,17 +387,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value))
 
 <a id="nestedatt--inheritance_sources--forwarders_block--value"></a>
 ### Nested Schema for `inheritance_sources.forwarders_block.value`
 
-Optional:
+Read-Only:
 
 - `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value--forwarders))
 - `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
@@ -424,13 +406,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--forwarders_block--value--forwarders"></a>
 ### Nested Schema for `inheritance_sources.forwarders_block.value.use_root_forwarders_for_local_resolution_with_b1td`
 
-Required:
+Read-Only:
 
 - `address` (String) Server IP address.
 - `fqdn` (String) Server FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) Server FQDN in punycode.
 
 
@@ -442,11 +421,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -456,24 +435,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--kerberos_keys--value))
 
 <a id="nestedatt--inheritance_sources--kerberos_keys--value"></a>
 ### Nested Schema for `inheritance_sources.kerberos_keys.value`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) Encryption algorithm of the key in accordance with RFC 3961.
 - `domain` (String) Kerberos realm of the principal.
+- `key` (String) The resource identifier.
 - `principal` (String) Kerberos principal associated with key.
 - `uploaded_at` (String) Upload time for the key.
 - `version` (Number) The version number (KVNO) of the key.
@@ -486,11 +462,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -500,11 +476,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -514,11 +490,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -528,11 +504,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -542,11 +518,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -556,11 +532,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -570,11 +546,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -584,38 +560,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -629,11 +599,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -643,38 +613,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--recursion_acl--value))
 
 <a id="nestedatt--inheritance_sources--recursion_acl--value"></a>
 ### Nested Schema for `inheritance_sources.recursion_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--recursion_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--recursion_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.recursion_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -688,11 +652,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -702,11 +666,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -716,11 +680,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -730,11 +694,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -744,11 +708,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -758,23 +722,20 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--sort_list--value))
 
 <a id="nestedatt--inheritance_sources--sort_list--value"></a>
 ### Nested Schema for `inheritance_sources.sort_list.value`
 
-Required:
-
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
-
-Optional:
+Read-Only:
 
 - `acl` (String) The resource identifier.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
 - `prioritized_networks` (List of String) Optional. The prioritized networks. If empty, the value of _source_ or networks from _acl_ is used.
 - `source` (String) Must be empty if _element_ is not _ip_.
 
@@ -786,11 +747,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -800,38 +761,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -845,38 +800,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -890,11 +839,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 

--- a/docs/resources/dns_srv_record.md
+++ b/docs/resources/dns_srv_record.md
@@ -109,9 +109,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_svcb_record.md
+++ b/docs/resources/dns_svcb_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_txt_record.md
+++ b/docs/resources/dns_txt_record.md
@@ -94,9 +94,9 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.

--- a/docs/resources/dns_view.md
+++ b/docs/resources/dns_view.md
@@ -232,11 +232,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -246,17 +246,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value))
 
 <a id="nestedatt--inheritance_sources--custom_root_ns_block--value"></a>
 ### Nested Schema for `inheritance_sources.custom_root_ns_block.value`
 
-Optional:
+Read-Only:
 
 - `custom_root_ns` (Attributes List) Optional. Field config for _custom_root_ns_ field. (see [below for nested schema](#nestedatt--inheritance_sources--custom_root_ns_block--value--custom_root_ns))
 - `custom_root_ns_enabled` (Boolean) Optional. Field config for _custom_root_ns_enabled_ field.
@@ -264,13 +264,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--custom_root_ns_block--value--custom_root_ns"></a>
 ### Nested Schema for `inheritance_sources.custom_root_ns_block.value.custom_root_ns_enabled`
 
-Required:
+Read-Only:
 
 - `address` (String) IPv4 address.
 - `fqdn` (String) FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) FQDN in punycode.
 
 
@@ -282,17 +279,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dnssec_validation_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dnssec_validation_block--value))
 
 <a id="nestedatt--inheritance_sources--dnssec_validation_block--value"></a>
 ### Nested Schema for `inheritance_sources.dnssec_validation_block.value`
 
-Optional:
+Read-Only:
 
 - `dnssec_enable_validation` (Boolean) Optional. Field config for _dnssec_enable_validation_ field.
 - `dnssec_enabled` (Boolean) Optional. Field config for _dnssec_enabled_ field.
@@ -302,19 +299,13 @@ Optional:
 <a id="nestedatt--inheritance_sources--dnssec_validation_block--value--dnssec_trust_anchors"></a>
 ### Nested Schema for `inheritance_sources.dnssec_validation_block.value.dnssec_validate_expiry`
 
-Required:
-
-- `algorithm` (Number)
-- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
-- `zone` (String) Zone FQDN.
-
-Optional:
-
-- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
-
 Read-Only:
 
+- `algorithm` (Number)
 - `protocol_zone` (String) Zone FQDN in punycode.
+- `public_key` (String) DNSSEC key data. Non-empty, valid base64 string.
+- `sep` (Boolean) Optional. Secure Entry Point flag.  Defaults to _true_.
+- `zone` (String) Zone FQDN.
 
 
 
@@ -332,11 +323,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -347,17 +338,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ecs_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ecs_block--value))
 
 <a id="nestedatt--inheritance_sources--ecs_block--value"></a>
 ### Nested Schema for `inheritance_sources.ecs_block.value`
 
-Optional:
+Read-Only:
 
 - `ecs_enabled` (Boolean) Optional. Field config for _ecs_enabled_ field.
 - `ecs_forwarding` (Boolean) Optional. Field config for _ecs_forwarding_ field.
@@ -368,13 +359,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--ecs_block--value--ecs_zones"></a>
 ### Nested Schema for `inheritance_sources.ecs_block.value.ecs_zones`
 
-Required:
+Read-Only:
 
 - `access` (String) Access control for zone.  Allowed values: * _allow_, * _deny_.
 - `fqdn` (String) Zone FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) Zone FQDN in punycode.
 
 
@@ -386,11 +374,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -400,38 +388,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--filter_aaaa_acl--value))
 
 <a id="nestedatt--inheritance_sources--filter_aaaa_acl--value"></a>
 ### Nested Schema for `inheritance_sources.filter_aaaa_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--filter_aaaa_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--filter_aaaa_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.filter_aaaa_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -445,11 +427,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -459,17 +441,17 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value))
 
 <a id="nestedatt--inheritance_sources--forwarders_block--value"></a>
 ### Nested Schema for `inheritance_sources.forwarders_block.value`
 
-Optional:
+Read-Only:
 
 - `forwarders` (Attributes List) Optional. Field config for _forwarders_ field from. (see [below for nested schema](#nestedatt--inheritance_sources--forwarders_block--value--forwarders))
 - `forwarders_only` (Boolean) Optional. Field config for _forwarders_only_ field.
@@ -478,13 +460,10 @@ Optional:
 <a id="nestedatt--inheritance_sources--forwarders_block--value--forwarders"></a>
 ### Nested Schema for `inheritance_sources.forwarders_block.value.use_root_forwarders_for_local_resolution_with_b1td`
 
-Required:
+Read-Only:
 
 - `address` (String) Server IP address.
 - `fqdn` (String) Server FQDN.
-
-Read-Only:
-
 - `protocol_fqdn` (String) Server FQDN in punycode.
 
 
@@ -496,11 +475,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -510,11 +489,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -524,11 +503,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -538,11 +517,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -552,11 +531,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -566,11 +545,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -580,11 +559,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -594,11 +573,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -608,38 +587,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value))
 
 <a id="nestedatt--inheritance_sources--query_acl--value"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--query_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--query_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.query_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -653,38 +626,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--recursion_acl--value))
 
 <a id="nestedatt--inheritance_sources--recursion_acl--value"></a>
 ### Nested Schema for `inheritance_sources.recursion_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--recursion_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--recursion_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.recursion_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -698,11 +665,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -712,23 +679,20 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--sort_list--value))
 
 <a id="nestedatt--inheritance_sources--sort_list--value"></a>
 ### Nested Schema for `inheritance_sources.sort_list.value`
 
-Required:
-
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
-
-Optional:
+Read-Only:
 
 - `acl` (String) The resource identifier.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,
 - `prioritized_networks` (List of String) Optional. The prioritized networks. If empty, the value of _source_ or networks from _acl_ is used.
 - `source` (String) Must be empty if _element_ is not _ip_.
 
@@ -740,11 +704,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -754,38 +718,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--transfer_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--transfer_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.transfer_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -799,38 +757,32 @@ Read-Only:
 Optional:
 
 - `action` (String) Optional. Inheritance setting for a field. Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) Inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value))
 
 <a id="nestedatt--inheritance_sources--update_acl--value"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value`
 
-Required:
+Read-Only:
 
 - `access` (String) Access permission for _element_.  Allowed values:  * _allow_,  * _deny_.
-- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
-
-Optional:
-
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.  Allowed values:  * _any_,  * _ip_,  * _acl_,  * _tsig_key_.
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--update_acl--value--tsig_key))
 
 <a id="nestedatt--inheritance_sources--update_acl--value--tsig_key"></a>
 ### Nested Schema for `inheritance_sources.update_acl.value.tsig_key`
 
-Required:
-
-- `key` (String) The resource identifier.
-
 Read-Only:
 
 - `algorithm` (String) TSIG key algorithm.  Possible values:  * _hmac_sha256_,  * _hmac_sha1_,  * _hmac_sha224_,  * _hmac_sha384_,  * _hmac_sha512_.
 - `comment` (String) Comment for TSIG key.
+- `key` (String) The resource identifier.
 - `name` (String) TSIG key name, FQDN.
 - `protocol_name` (String) TSIG key name in punycode.
 - `secret` (String, Sensitive) TSIG key secret, base64 string.
@@ -844,11 +796,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -872,11 +824,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -886,11 +838,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -900,24 +852,21 @@ Read-Only:
 Optional:
 
 - `action` (String) Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--zone_authority--mname_block--value))
 
 Read-Only:
 
 - `display_name` (String) Human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--zone_authority--mname_block--value))
 
 <a id="nestedatt--inheritance_sources--zone_authority--mname_block--value"></a>
-### Nested Schema for `inheritance_sources.zone_authority.mname_block.display_name`
-
-Optional:
-
-- `mname` (String) Defaults to empty.
-- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
+### Nested Schema for `inheritance_sources.zone_authority.mname_block.value`
 
 Read-Only:
 
+- `mname` (String) Defaults to empty.
 - `protocol_mname` (String) Optional. Master name server in punycode.  Defaults to empty.
+- `use_default_mname` (Boolean) Optional. Use default value for master name server.  Defaults to true.
 
 
 
@@ -927,11 +876,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -941,11 +890,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -955,11 +904,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -969,11 +918,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -983,11 +932,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 

--- a/docs/resources/ipam_address_block.md
+++ b/docs/resources/ipam_address_block.md
@@ -197,17 +197,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_enable_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -221,17 +221,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_growth_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -244,11 +244,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -258,11 +258,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -272,11 +272,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -286,11 +286,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -300,11 +300,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -315,11 +315,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -329,11 +329,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -343,11 +343,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -357,17 +357,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_hostname_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -380,11 +380,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -394,17 +394,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_update_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -417,11 +417,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -431,11 +431,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -461,11 +461,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -475,11 +475,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -489,11 +489,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -503,11 +503,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -517,12 +517,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -531,12 +531,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -545,11 +545,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -559,17 +559,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_config--ignore_list--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_list--value"></a>
 ### Nested Schema for `inheritance_sources.dhcp_config.ignore_list.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -582,11 +582,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -596,11 +596,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -619,25 +619,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -654,11 +654,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -668,11 +668,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -682,11 +682,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -696,17 +696,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--inheritance_sources--hostname_rewrite_block--value"></a>
 ### Nested Schema for `inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.

--- a/docs/resources/ipam_ip_space.md
+++ b/docs/resources/ipam_ip_space.md
@@ -176,17 +176,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_enable_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -200,17 +200,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_growth_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -223,11 +223,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -237,11 +237,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -251,11 +251,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -265,11 +265,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -279,11 +279,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -294,11 +294,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -308,11 +308,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -322,11 +322,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -336,17 +336,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_hostname_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -359,11 +359,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -373,17 +373,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_update_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -396,11 +396,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -410,11 +410,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -440,11 +440,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -454,11 +454,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -468,11 +468,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -482,11 +482,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -496,12 +496,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -510,12 +510,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -524,11 +524,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -538,17 +538,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_config--ignore_list--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_list--value"></a>
 ### Nested Schema for `inheritance_sources.dhcp_config.ignore_list.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -561,11 +561,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -575,11 +575,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -598,25 +598,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -641,25 +641,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options_v6--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options_v6.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options_v6.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options_v6--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options_v6--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options_v6.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options_v6--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options_v6.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -676,11 +676,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -690,11 +690,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -704,11 +704,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -718,17 +718,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--inheritance_sources--hostname_rewrite_block--value"></a>
 ### Nested Schema for `inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.
@@ -742,12 +742,12 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (String) The resource identifier.
 
 
 

--- a/docs/resources/ipam_range.md
+++ b/docs/resources/ipam_range.md
@@ -139,25 +139,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.

--- a/docs/resources/ipam_subnet.md
+++ b/docs/resources/ipam_subnet.md
@@ -203,17 +203,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_enable_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_enable_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_enable_block.value`
 
-Optional:
+Read-Only:
 
 - `enable` (Boolean) Indicates whether Automated Scope Management is enabled or not.
 - `enable_notification` (Boolean) Indicates whether sending notifications to the users is enabled or not.
@@ -227,17 +227,17 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--asm_config--asm_growth_block--value))
 
 <a id="nestedatt--inheritance_sources--asm_config--asm_growth_block--value"></a>
-### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.display_name`
+### Nested Schema for `inheritance_sources.asm_config.asm_growth_block.value`
 
-Optional:
+Read-Only:
 
 - `growth_factor` (Number) Either the number or percentage of addresses to grow by.
 - `growth_type` (String) The type of factor to use: _percent_ or _count_.
@@ -250,11 +250,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -264,11 +264,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -278,11 +278,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -292,11 +292,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -306,11 +306,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -321,11 +321,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -335,11 +335,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -349,11 +349,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -363,17 +363,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_hostname_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_hostname_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_hostname_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_generate_name` (Boolean) Indicates if DDNS should generate a hostname when not supplied by the client.
 - `ddns_generated_prefix` (String) The prefix used in the generation of an FQDN.
@@ -386,11 +386,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -400,17 +400,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--ddns_update_block--value))
 
 <a id="nestedatt--inheritance_sources--ddns_update_block--value"></a>
 ### Nested Schema for `inheritance_sources.ddns_update_block.value`
 
-Optional:
+Read-Only:
 
 - `ddns_domain` (String) The domain name for DDNS.
 - `ddns_send_updates` (Boolean) Determines if DDNS updates are enabled at this level.
@@ -423,11 +423,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -437,11 +437,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -467,11 +467,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -481,11 +481,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -495,11 +495,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -509,11 +509,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -523,12 +523,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--filters_v6"></a>
@@ -537,12 +537,12 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (List of String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (List of String) The resource identifier.
 
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_client_uid"></a>
@@ -551,11 +551,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Boolean) The inherited value.
 
 
@@ -565,17 +565,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Attributes List) The inherited value. (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_config--ignore_list--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_config--ignore_list--value"></a>
 ### Nested Schema for `inheritance_sources.dhcp_config.ignore_list.value`
 
-Required:
+Read-Only:
 
 - `type` (String) Type of ignore matching: client to ignore by client identifier (client hex or client text) or hardware to ignore by hardware identifier (MAC address). It can have one of the following values:  * _client_hex_,  * _client_text_,  * _hardware_.
 - `value` (String) Value to match.
@@ -588,11 +588,11 @@ Required:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -602,11 +602,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (Number) The inherited value.
 
 
@@ -625,25 +625,25 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value))
 
 <a id="nestedatt--inheritance_sources--dhcp_options--value--value"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name`
+### Nested Schema for `inheritance_sources.dhcp_options.value.value`
 
-Optional:
+Read-Only:
 
-- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--display_name--option))
+- `option` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--dhcp_options--value--value--option))
 - `overriding_group` (String) The resource identifier.
 
-<a id="nestedatt--inheritance_sources--dhcp_options--value--display_name--option"></a>
-### Nested Schema for `inheritance_sources.dhcp_options.value.display_name.option`
+<a id="nestedatt--inheritance_sources--dhcp_options--value--value--option"></a>
+### Nested Schema for `inheritance_sources.dhcp_options.value.value.option`
 
-Optional:
+Read-Only:
 
 - `group` (String) The resource identifier.
 - `option_code` (String) The resource identifier.
@@ -660,11 +660,11 @@ Optional:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -674,11 +674,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -688,11 +688,11 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
 - `value` (String) The inherited value.
 
 
@@ -702,17 +702,17 @@ Read-Only:
 Optional:
 
 - `action` (String) The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.
-- `source` (String) The resource identifier.
-- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 Read-Only:
 
 - `display_name` (String) The human-readable display name for the object referred to by _source_.
+- `source` (String) The resource identifier.
+- `value` (Attributes) (see [below for nested schema](#nestedatt--inheritance_sources--hostname_rewrite_block--value))
 
 <a id="nestedatt--inheritance_sources--hostname_rewrite_block--value"></a>
 ### Nested Schema for `inheritance_sources.hostname_rewrite_block.value`
 
-Optional:
+Read-Only:
 
 - `hostname_rewrite_char` (String) The inheritance configuration for _hostname_rewrite_char_ field.
 - `hostname_rewrite_enabled` (Boolean) The inheritance configuration for _hostname_rewrite_enabled_ field.

--- a/internal/service/dns_config/model_config_auth_zone.go
+++ b/internal/service/dns_config/model_config_auth_zone.go
@@ -2,18 +2,20 @@ package dns_config
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
@@ -150,6 +152,10 @@ var ConfigAuthZoneResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: ConfigAuthZoneInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"initial_soa_serial": schema.Int64Attribute{
 		Optional: true,
@@ -335,7 +341,7 @@ func (m *ConfigAuthZoneModel) Flatten(ctx context.Context, from *dns_config.Conf
 	m.Id = flex.FlattenStringPointer(from.Id)
 	m.InheritanceAssignedHosts = flex.FlattenFrameworkListNestedBlock(ctx, from.InheritanceAssignedHosts, Inheritance2AssignedHostAttrTypes, diags, FlattenInheritance2AssignedHost)
 	m.InheritanceSources = FlattenConfigAuthZoneInheritance(ctx, from.InheritanceSources, diags)
-	m.InitialSoaSerial = flex.FlattenInt64(int64(*from.InitialSoaSerial))
+	m.InitialSoaSerial = flex.FlattenInt64Pointer(from.InitialSoaSerial)
 	m.InternalSecondaries = flex.FlattenFrameworkListNestedBlock(ctx, from.InternalSecondaries, ConfigInternalSecondaryAttrTypes, diags, FlattenConfigInternalSecondary)
 	m.MappedSubnet = flex.FlattenStringPointer(from.MappedSubnet)
 	m.Mapping = flex.FlattenStringPointer(from.Mapping)

--- a/internal/service/dns_config/model_config_auth_zone_inheritance.go
+++ b/internal/service/dns_config/model_config_auth_zone_inheritance.go
@@ -36,30 +36,37 @@ var ConfigAuthZoneInheritanceResourceSchemaAttributes = map[string]schema.Attrib
 	"gss_tsig_enabled": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"notify": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"query_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"transfer_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"update_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"use_forwarders_for_subzones": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"zone_authority": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedZoneAuthorityResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_host.go
+++ b/internal/service/dns_config/model_config_host.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -105,7 +106,11 @@ var ConfigHostResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes:          ConfigHostInheritanceResourceSchemaAttributes,
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "Optional. Inheritance configuration.",
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"kerberos_keys": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{

--- a/internal/service/dns_config/model_config_host_inheritance.go
+++ b/internal/service/dns_config/model_config_host_inheritance.go
@@ -25,6 +25,7 @@ var ConfigHostInheritanceResourceSchemaAttributes = map[string]schema.Attribute{
 	"kerberos_keys": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedKerberosKeysResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_acl_items.go
+++ b/internal/service/dns_config/model_config_inherited_acl_items.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,22 +32,23 @@ var ConfigInheritedACLItemsAttrTypes = map[string]attr.Type{
 var ConfigInheritedACLItemsResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Optional. Inheritance setting for a field. Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
 		Computed:            true,
-		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
+		MarkdownDescription: "Human-readable display name for the object referred to by _source_.",
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
-		MarkdownDescription: `The resource identifier.`,
+		Computed:            true,
+		MarkdownDescription: "The resource identifier.",
 	},
 	"value": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: ConfigACLItemResourceSchemaAttributes,
+			Attributes: utils.ToComputedAttributeMap(ConfigACLItemResourceSchemaAttributes),
 		},
 		Computed:            true,
-		MarkdownDescription: `Inherited value.`,
+		MarkdownDescription: "Inherited value.",
 	},
 }
 
@@ -68,7 +70,6 @@ func (m *ConfigInheritedACLItemsModel) Expand(ctx context.Context, diags *diag.D
 	}
 	to := &dns_config.ConfigInheritedACLItems{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_custom_root_ns_block.go
+++ b/internal/service/dns_config/model_config_inherited_custom_root_ns_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedCustomRootNSBlockAttrTypes = map[string]attr.Type{
 var ConfigInheritedCustomRootNSBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedCustomRootNSBlockResourceSchemaAttributes = map[string]schema
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: ConfigCustomRootNSBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(ConfigCustomRootNSBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_custom_root_ns_block.go
+++ b/internal/service/dns_config/model_config_inherited_custom_root_ns_block.go
@@ -67,8 +67,6 @@ func (m *ConfigInheritedCustomRootNSBlockModel) Expand(ctx context.Context, diag
 	}
 	to := &dns_config.ConfigInheritedCustomRootNSBlock{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
-		Value:  ExpandConfigCustomRootNSBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_dnssec_validation_block.go
+++ b/internal/service/dns_config/model_config_inherited_dnssec_validation_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedDNSSECValidationBlockAttrTypes = map[string]attr.Type{
 var ConfigInheritedDNSSECValidationBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedDNSSECValidationBlockResourceSchemaAttributes = map[string]sc
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: ConfigDNSSECValidationBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(ConfigDNSSECValidationBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_dnssec_validation_block.go
+++ b/internal/service/dns_config/model_config_inherited_dnssec_validation_block.go
@@ -67,8 +67,6 @@ func (m *ConfigInheritedDNSSECValidationBlockModel) Expand(ctx context.Context, 
 	}
 	to := &dns_config.ConfigInheritedDNSSECValidationBlock{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
-		Value:  ExpandConfigDNSSECValidationBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_dtc_config.go
+++ b/internal/service/dns_config/model_config_inherited_dtc_config.go
@@ -24,6 +24,7 @@ var ConfigInheritedDtcConfigResourceSchemaAttributes = map[string]schema.Attribu
 	"default_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_ecs_block.go
+++ b/internal/service/dns_config/model_config_inherited_ecs_block.go
@@ -67,8 +67,6 @@ func (m *ConfigInheritedECSBlockModel) Expand(ctx context.Context, diags *diag.D
 	}
 	to := &dns_config.ConfigInheritedECSBlock{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
-		Value:  ExpandConfigECSBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_ecs_block.go
+++ b/internal/service/dns_config/model_config_inherited_ecs_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedECSBlockAttrTypes = map[string]attr.Type{
 var ConfigInheritedECSBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedECSBlockResourceSchemaAttributes = map[string]schema.Attribut
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: ConfigECSBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(ConfigECSBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_forwarders_block.go
+++ b/internal/service/dns_config/model_config_inherited_forwarders_block.go
@@ -67,8 +67,6 @@ func (m *ConfigInheritedForwardersBlockModel) Expand(ctx context.Context, diags 
 	}
 	to := &dns_config.ConfigInheritedForwardersBlock{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
-		Value:  ExpandConfigForwardersBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_forwarders_block.go
+++ b/internal/service/dns_config/model_config_inherited_forwarders_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedForwardersBlockAttrTypes = map[string]attr.Type{
 var ConfigInheritedForwardersBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedForwardersBlockResourceSchemaAttributes = map[string]schema.A
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: ConfigForwardersBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(ConfigForwardersBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_kerberos_keys.go
+++ b/internal/service/dns_config/model_config_inherited_kerberos_keys.go
@@ -70,7 +70,6 @@ func (m *ConfigInheritedKerberosKeysModel) Expand(ctx context.Context, diags *di
 	}
 	to := &dns_config.ConfigInheritedKerberosKeys{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_kerberos_keys.go
+++ b/internal/service/dns_config/model_config_inherited_kerberos_keys.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedKerberosKeysAttrTypes = map[string]attr.Type{
 var ConfigInheritedKerberosKeysResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Optional. Inheritance setting for a field. Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedKerberosKeysResourceSchemaAttributes = map[string]schema.Attr
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: ConfigKerberosKeyResourceSchemaAttributes,
+			Attributes: utils.ToComputedAttributeMap(ConfigKerberosKeyResourceSchemaAttributes),
 		},
 		Computed:            true,
 		MarkdownDescription: `Inherited value.`,

--- a/internal/service/dns_config/model_config_inherited_sort_list_items.go
+++ b/internal/service/dns_config/model_config_inherited_sort_list_items.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var ConfigInheritedSortListItemsAttrTypes = map[string]attr.Type{
 var ConfigInheritedSortListItemsResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Optional. Inheritance setting for a field. Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var ConfigInheritedSortListItemsResourceSchemaAttributes = map[string]schema.Att
 		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: ConfigSortListItemResourceSchemaAttributes,
+			Attributes: utils.ToComputedAttributeMap(ConfigSortListItemResourceSchemaAttributes),
 		},
 		Computed:            true,
 		MarkdownDescription: `Inherited value.`,

--- a/internal/service/dns_config/model_config_inherited_sort_list_items.go
+++ b/internal/service/dns_config/model_config_inherited_sort_list_items.go
@@ -70,7 +70,6 @@ func (m *ConfigInheritedSortListItemsModel) Expand(ctx context.Context, diags *d
 	}
 	to := &dns_config.ConfigInheritedSortListItems{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_inherited_zone_authority.go
+++ b/internal/service/dns_config/model_config_inherited_zone_authority.go
@@ -38,34 +38,42 @@ var ConfigInheritedZoneAuthorityResourceSchemaAttributes = map[string]schema.Att
 	"default_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"expire": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"mname_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedZoneAuthorityMNameBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"negative_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"protocol_rname": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"refresh": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"retry": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"rname": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_inherited_zone_authority_m_name_block.go
+++ b/internal/service/dns_config/model_config_inherited_zone_authority_m_name_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,19 +32,20 @@ var ConfigInheritedZoneAuthorityMNameBlockAttrTypes = map[string]attr.Type{
 var ConfigInheritedZoneAuthorityMNameBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
 		Computed:            true,
-		MarkdownDescription: `Human-readable display name for the object referred to by _source_.`,
+		MarkdownDescription: "Human-readable display name for the object referred to by _source_.",
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
-		MarkdownDescription: `The resource identifier.`,
+		Computed:            true,
+		MarkdownDescription: "The resource identifier.",
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: ConfigZoneAuthorityMNameBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(ConfigZoneAuthorityMNameBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 
@@ -65,8 +67,6 @@ func (m *ConfigInheritedZoneAuthorityMNameBlockModel) Expand(ctx context.Context
 	}
 	to := &dns_config.ConfigInheritedZoneAuthorityMNameBlock{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
-		Value:  ExpandConfigZoneAuthorityMNameBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_config_server.go
+++ b/internal/service/dns_config/model_config_server.go
@@ -9,6 +9,7 @@ import (
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -265,6 +266,10 @@ var ConfigServerResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: ConfigServerInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"kerberos_keys": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{

--- a/internal/service/dns_config/model_config_server_inheritance.go
+++ b/internal/service/dns_config/model_config_server_inheritance.go
@@ -80,118 +80,147 @@ var ConfigServerInheritanceResourceSchemaAttributes = map[string]schema.Attribut
 	"add_edns_option_in_outgoing_query": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"custom_root_ns_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedCustomRootNSBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dnssec_validation_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedDNSSECValidationBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ecs_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedECSBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filter_aaaa_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filter_aaaa_on_v4": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"forwarders_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedForwardersBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"gss_tsig_enabled": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"kerberos_keys": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedKerberosKeysResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"lame_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"log_query_response": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"match_recursive_only": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"max_cache_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"max_negative_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"minimal_responses": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"notify": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"query_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"query_port": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"recursion_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"recursion_enabled": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"recursive_clients": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"resolver_query_timeout": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"secondary_axfr_query_limit": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"secondary_soa_query_limit": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"sort_list": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedSortListItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"synthesize_address_records_from_https": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"transfer_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"update_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"use_forwarders_for_subzones": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_config_view.go
+++ b/internal/service/dns_config/model_config_view.go
@@ -2,6 +2,7 @@ package dns_config
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -288,6 +290,10 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: ConfigViewInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"ip_spaces": schema.ListAttribute{
 		ElementType: types.StringType,

--- a/internal/service/dns_config/model_config_view_inheritance.go
+++ b/internal/service/dns_config/model_config_view_inheritance.go
@@ -74,106 +74,132 @@ var ConfigViewInheritanceResourceSchemaAttributes = map[string]schema.Attribute{
 	"add_edns_option_in_outgoing_query": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"custom_root_ns_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedCustomRootNSBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dnssec_validation_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedDNSSECValidationBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dtc_config": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedDtcConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ecs_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedECSBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"edns_udp_size": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filter_aaaa_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filter_aaaa_on_v4": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"forwarders_block": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedForwardersBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"gss_tsig_enabled": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"lame_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"match_recursive_only": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"max_cache_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"max_negative_ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"max_udp_size": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"minimal_responses": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"notify": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"query_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"recursion_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"recursion_enabled": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"sort_list": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedSortListItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"synthesize_address_records_from_https": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"transfer_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"update_acl": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedACLItemsResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"use_forwarders_for_subzones": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"zone_authority": schema.SingleNestedAttribute{
 		Attributes: ConfigInheritedZoneAuthorityResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_config/model_inheritance2_inherited_bool.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_bool.go
@@ -66,7 +66,6 @@ func (m *Inheritance2InheritedBoolModel) Expand(ctx context.Context, diags *diag
 	}
 	to := &dns_config.Inheritance2InheritedBool{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_inheritance2_inherited_bool.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_bool.go
@@ -31,6 +31,7 @@ var Inheritance2InheritedBoolAttrTypes = map[string]attr.Type{
 var Inheritance2InheritedBoolResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var Inheritance2InheritedBoolResourceSchemaAttributes = map[string]schema.Attrib
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.BoolAttribute{

--- a/internal/service/dns_config/model_inheritance2_inherited_string.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_string.go
@@ -66,7 +66,6 @@ func (m *Inheritance2InheritedStringModel) Expand(ctx context.Context, diags *di
 	}
 	to := &dns_config.Inheritance2InheritedString{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_config/model_inheritance2_inherited_string.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_string.go
@@ -31,6 +31,7 @@ var Inheritance2InheritedStringAttrTypes = map[string]attr.Type{
 var Inheritance2InheritedStringResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var Inheritance2InheritedStringResourceSchemaAttributes = map[string]schema.Attr
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.StringAttribute{

--- a/internal/service/dns_config/model_inheritance2_inherited_u_int32.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_u_int32.go
@@ -31,6 +31,7 @@ var Inheritance2InheritedUInt32AttrTypes = map[string]attr.Type{
 var Inheritance2InheritedUInt32ResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var Inheritance2InheritedUInt32ResourceSchemaAttributes = map[string]schema.Attr
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.Int64Attribute{

--- a/internal/service/dns_config/model_inheritance2_inherited_u_int32.go
+++ b/internal/service/dns_config/model_inheritance2_inherited_u_int32.go
@@ -66,7 +66,6 @@ func (m *Inheritance2InheritedUInt32Model) Expand(ctx context.Context, diags *di
 	}
 	to := &dns_config.Inheritance2InheritedUInt32{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_data/model_data_record.go
+++ b/internal/service/dns_data/model_data_record.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -139,6 +140,10 @@ func recordCommonSchema() map[string]schema.Attribute {
 		"inheritance_sources": schema.SingleNestedAttribute{
 			Attributes: DataRecordInheritanceResourceSchemaAttributes,
 			Optional:   true,
+			Computed:   true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"ipam_host": schema.StringAttribute{
 			Computed:            true,

--- a/internal/service/dns_data/model_data_record_inheritance.go
+++ b/internal/service/dns_data/model_data_record_inheritance.go
@@ -24,6 +24,7 @@ var DataRecordInheritanceResourceSchemaAttributes = map[string]schema.Attribute{
 	"ttl": schema.SingleNestedAttribute{
 		Attributes: Inheritance2InheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/dns_data/model_inheritance2_inherited_u_int32.go
+++ b/internal/service/dns_data/model_inheritance2_inherited_u_int32.go
@@ -66,7 +66,6 @@ func (m *Inheritance2InheritedUInt32Model) Expand(ctx context.Context, diags *di
 	}
 	to := &dns_data.Inheritance2InheritedUInt32{
 		Action: flex.ExpandStringPointer(m.Action),
-		Source: flex.ExpandStringPointer(m.Source),
 	}
 	return to
 }

--- a/internal/service/dns_data/model_inheritance2_inherited_u_int32.go
+++ b/internal/service/dns_data/model_inheritance2_inherited_u_int32.go
@@ -31,6 +31,7 @@ var Inheritance2InheritedUInt32AttrTypes = map[string]attr.Type{
 var Inheritance2InheritedUInt32ResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.",
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var Inheritance2InheritedUInt32ResourceSchemaAttributes = map[string]schema.Attr
 		MarkdownDescription: "The human-readable display name for the object referred to by _source_.",
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: "The resource identifier.",
 	},
 	"value": schema.Int64Attribute{

--- a/internal/service/ipam/model_inheritance_inherited_bool.go
+++ b/internal/service/ipam/model_inheritance_inherited_bool.go
@@ -66,7 +66,6 @@ func (m *InheritanceInheritedBoolModel) Expand(ctx context.Context, diags *diag.
 	}
 	to := &ipam.InheritanceInheritedBool{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inheritance_inherited_bool.go
+++ b/internal/service/ipam/model_inheritance_inherited_bool.go
@@ -31,6 +31,7 @@ var InheritanceInheritedBoolAttrTypes = map[string]attr.Type{
 var InheritanceInheritedBoolResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var InheritanceInheritedBoolResourceSchemaAttributes = map[string]schema.Attribu
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.BoolAttribute{

--- a/internal/service/ipam/model_inheritance_inherited_float.go
+++ b/internal/service/ipam/model_inheritance_inherited_float.go
@@ -31,6 +31,7 @@ var InheritanceInheritedFloatAttrTypes = map[string]attr.Type{
 var InheritanceInheritedFloatResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var InheritanceInheritedFloatResourceSchemaAttributes = map[string]schema.Attrib
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.Float64Attribute{

--- a/internal/service/ipam/model_inheritance_inherited_float.go
+++ b/internal/service/ipam/model_inheritance_inherited_float.go
@@ -66,7 +66,6 @@ func (m *InheritanceInheritedFloatModel) Expand(ctx context.Context, diags *diag
 	}
 	to := &ipam.InheritanceInheritedFloat{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inheritance_inherited_identifier.go
+++ b/internal/service/ipam/model_inheritance_inherited_identifier.go
@@ -66,8 +66,6 @@ func (m *InheritanceInheritedIdentifierModel) Expand(ctx context.Context, diags 
 	}
 	to := &ipam.InheritanceInheritedIdentifier{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  m.Value.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inheritance_inherited_identifier.go
+++ b/internal/service/ipam/model_inheritance_inherited_identifier.go
@@ -31,6 +31,7 @@ var InheritanceInheritedIdentifierAttrTypes = map[string]attr.Type{
 var InheritanceInheritedIdentifierResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,11 +39,11 @@ var InheritanceInheritedIdentifierResourceSchemaAttributes = map[string]schema.A
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 }

--- a/internal/service/ipam/model_inheritance_inherited_string.go
+++ b/internal/service/ipam/model_inheritance_inherited_string.go
@@ -31,6 +31,7 @@ var InheritanceInheritedStringAttrTypes = map[string]attr.Type{
 var InheritanceInheritedStringResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var InheritanceInheritedStringResourceSchemaAttributes = map[string]schema.Attri
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.StringAttribute{

--- a/internal/service/ipam/model_inheritance_inherited_string.go
+++ b/internal/service/ipam/model_inheritance_inherited_string.go
@@ -66,7 +66,6 @@ func (m *InheritanceInheritedStringModel) Expand(ctx context.Context, diags *dia
 	}
 	to := &ipam.InheritanceInheritedString{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inheritance_inherited_u_int32.go
+++ b/internal/service/ipam/model_inheritance_inherited_u_int32.go
@@ -31,6 +31,7 @@ var InheritanceInheritedUInt32AttrTypes = map[string]attr.Type{
 var InheritanceInheritedUInt32ResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting for a field.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,7 +39,7 @@ var InheritanceInheritedUInt32ResourceSchemaAttributes = map[string]schema.Attri
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.Int64Attribute{

--- a/internal/service/ipam/model_inheritance_inherited_u_int32.go
+++ b/internal/service/ipam/model_inheritance_inherited_u_int32.go
@@ -66,7 +66,6 @@ func (m *InheritanceInheritedUInt32Model) Expand(ctx context.Context, diags *dia
 	}
 	to := &ipam.InheritanceInheritedUInt32{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inherited_dhcp_config_filter_list.go
+++ b/internal/service/ipam/model_inherited_dhcp_config_filter_list.go
@@ -31,6 +31,7 @@ var InheritedDHCPConfigFilterListAttrTypes = map[string]attr.Type{
 var InheritedDHCPConfigFilterListResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +39,12 @@ var InheritedDHCPConfigFilterListResourceSchemaAttributes = map[string]schema.At
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.ListAttribute{
 		ElementType:         types.StringType,
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 }

--- a/internal/service/ipam/model_inherited_dhcp_config_filter_list.go
+++ b/internal/service/ipam/model_inherited_dhcp_config_filter_list.go
@@ -67,8 +67,6 @@ func (m *InheritedDHCPConfigFilterListModel) Expand(ctx context.Context, diags *
 	}
 	to := &ipam.InheritedDHCPConfigFilterList{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  flex.ExpandFrameworkListString(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inherited_dhcp_config_ignore_item_list.go
+++ b/internal/service/ipam/model_inherited_dhcp_config_ignore_item_list.go
@@ -70,7 +70,6 @@ func (m *InheritedDHCPConfigIgnoreItemListModel) Expand(ctx context.Context, dia
 	}
 	to := &ipam.InheritedDHCPConfigIgnoreItemList{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
 	}
 	return to
 }

--- a/internal/service/ipam/model_inherited_dhcp_config_ignore_item_list.go
+++ b/internal/service/ipam/model_inherited_dhcp_config_ignore_item_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var InheritedDHCPConfigIgnoreItemListAttrTypes = map[string]attr.Type{
 var InheritedDHCPConfigIgnoreItemListResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var InheritedDHCPConfigIgnoreItemListResourceSchemaAttributes = map[string]schem
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.ListNestedAttribute{
 		NestedObject: schema.NestedAttributeObject{
-			Attributes: IpamsvcIgnoreItemResourceSchemaAttributes,
+			Attributes: utils.ToComputedAttributeMap(IpamsvcIgnoreItemResourceSchemaAttributes),
 		},
 		Computed:            true,
 		MarkdownDescription: `The inherited value.`,

--- a/internal/service/ipam/model_ipamsvc_address_block.go
+++ b/internal/service/ipam/model_ipamsvc_address_block.go
@@ -2,12 +2,14 @@ package ipam
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -278,6 +280,10 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: IpamsvcDHCPInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"name": schema.StringAttribute{
 		Optional:            true,

--- a/internal/service/ipam/model_ipamsvc_dhcp_inheritance.go
+++ b/internal/service/ipam/model_ipamsvc_dhcp_inheritance.go
@@ -52,62 +52,77 @@ var IpamsvcDHCPInheritanceResourceSchemaAttributes = map[string]schema.Attribute
 	"asm_config": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedASMConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_client_update": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_conflict_resolution_mode": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_enabled": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_hostname_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSHostnameBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_ttl_percent": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedFloatResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_update_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSUpdateBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_update_on_renew": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_use_conflict_resolution": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_options": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_filename": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_address": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_name": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"hostname_rewrite_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedHostnameRewriteBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_dhcp_options_inheritance.go
+++ b/internal/service/ipam/model_ipamsvc_dhcp_options_inheritance.go
@@ -24,6 +24,7 @@ var IpamsvcDHCPOptionsInheritanceResourceSchemaAttributes = map[string]schema.At
 	"dhcp_options": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_fixed_address.go
+++ b/internal/service/ipam/model_ipamsvc_fixed_address.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -141,6 +142,10 @@ var IpamsvcFixedAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: IpamsvcFixedAddressInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"ip_space": schema.StringAttribute{
 		Optional:            true,

--- a/internal/service/ipam/model_ipamsvc_fixed_address_inheritance.go
+++ b/internal/service/ipam/model_ipamsvc_fixed_address_inheritance.go
@@ -30,18 +30,22 @@ var IpamsvcFixedAddressInheritanceResourceSchemaAttributes = map[string]schema.A
 	"dhcp_options": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_filename": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_address": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_name": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_asm_config.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_asm_config.go
@@ -36,30 +36,37 @@ var IpamsvcInheritedASMConfigResourceSchemaAttributes = map[string]schema.Attrib
 	"asm_enable_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedAsmEnableBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"asm_growth_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedAsmGrowthBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"asm_threshold": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"forecast_period": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"history": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"min_total": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"min_unused": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_asm_enable_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_asm_enable_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedAsmEnableBlockModel) Expand(ctx context.Context, diags 
 	}
 	to := &ipam.IpamsvcInheritedAsmEnableBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcAsmEnableBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_asm_enable_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_asm_enable_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedAsmEnableBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedAsmEnableBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedAsmEnableBlockResourceSchemaAttributes = map[string]schema.A
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcAsmEnableBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcAsmEnableBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_asm_growth_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_asm_growth_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedAsmGrowthBlockModel) Expand(ctx context.Context, diags 
 	}
 	to := &ipam.IpamsvcInheritedAsmGrowthBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcAsmGrowthBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_asm_growth_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_asm_growth_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedAsmGrowthBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedAsmGrowthBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedAsmGrowthBlockResourceSchemaAttributes = map[string]schema.A
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcAsmGrowthBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcAsmGrowthBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedDDNSBlockModel) Expand(ctx context.Context, diags *diag
 	}
 	to := &ipam.IpamsvcInheritedDDNSBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcDDNSBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedDDNSBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedDDNSBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedDDNSBlockResourceSchemaAttributes = map[string]schema.Attrib
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDDNSBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcDDNSBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_hostname_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_hostname_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedDDNSHostnameBlockModel) Expand(ctx context.Context, dia
 	}
 	to := &ipam.IpamsvcInheritedDDNSHostnameBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcDDNSHostnameBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_hostname_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_hostname_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedDDNSHostnameBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedDDNSHostnameBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedDDNSHostnameBlockResourceSchemaAttributes = map[string]schem
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDDNSHostnameBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcDDNSHostnameBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_update_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_update_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedDDNSUpdateBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedDDNSUpdateBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedDDNSUpdateBlockResourceSchemaAttributes = map[string]schema.
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDDNSUpdateBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcDDNSUpdateBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_ddns_update_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_ddns_update_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedDDNSUpdateBlockModel) Expand(ctx context.Context, diags
 	}
 	to := &ipam.IpamsvcInheritedDDNSUpdateBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcDDNSUpdateBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_dhcp_config.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_dhcp_config.go
@@ -42,42 +42,52 @@ var IpamsvcInheritedDHCPConfigResourceSchemaAttributes = map[string]schema.Attri
 	"abandoned_reclaim_time": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"abandoned_reclaim_time_v6": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"allow_unknown": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"allow_unknown_v6": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filters": schema.SingleNestedAttribute{
 		Attributes: InheritedDHCPConfigFilterListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"filters_v6": schema.SingleNestedAttribute{
 		Attributes: InheritedDHCPConfigFilterListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ignore_client_uid": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ignore_list": schema.SingleNestedAttribute{
 		Attributes: InheritedDHCPConfigIgnoreItemListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"lease_time": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"lease_time_v6": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedUInt32ResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedDHCPOptionModel) Expand(ctx context.Context, diags *dia
 	}
 	to := &ipam.IpamsvcInheritedDHCPOption{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcInheritedDHCPOptionItem(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedDHCPOptionAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedDHCPOptionResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedDHCPOptionResourceSchemaAttributes = map[string]schema.Attri
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcInheritedDHCPOptionItemResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcInheritedDHCPOptionItemResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_dhcp_option_list.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_dhcp_option_list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
-
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
 
@@ -27,6 +26,7 @@ var IpamsvcInheritedDHCPOptionListAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedDHCPOptionListResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _block_: Don't use the inherited value.  Defaults to _inherit_.`,
 	},
 	"value": schema.ListNestedAttribute{
@@ -34,6 +34,7 @@ var IpamsvcInheritedDHCPOptionListResourceSchemaAttributes = map[string]schema.A
 			Attributes: IpamsvcInheritedDHCPOptionResourceSchemaAttributes,
 		},
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inherited DHCP option values.`,
 	},
 }

--- a/internal/service/ipam/model_ipamsvc_inherited_hostname_rewrite_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_hostname_rewrite_block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -31,6 +32,7 @@ var IpamsvcInheritedHostnameRewriteBlockAttrTypes = map[string]attr.Type{
 var IpamsvcInheritedHostnameRewriteBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	"action": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The inheritance setting.  Valid values are: * _inherit_: Use the inherited value. * _override_: Use the value set in the object.  Defaults to _inherit_.`,
 	},
 	"display_name": schema.StringAttribute{
@@ -38,12 +40,12 @@ var IpamsvcInheritedHostnameRewriteBlockResourceSchemaAttributes = map[string]sc
 		MarkdownDescription: `The human-readable display name for the object referred to by _source_.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Computed:            true,
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"value": schema.SingleNestedAttribute{
-		Attributes: IpamsvcHostnameRewriteBlockResourceSchemaAttributes,
-		Optional:   true,
+		Attributes: utils.ToComputedAttributeMap(IpamsvcHostnameRewriteBlockResourceSchemaAttributes),
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_inherited_hostname_rewrite_block.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_hostname_rewrite_block.go
@@ -67,8 +67,6 @@ func (m *IpamsvcInheritedHostnameRewriteBlockModel) Expand(ctx context.Context, 
 	}
 	to := &ipam.IpamsvcInheritedHostnameRewriteBlock{
 		Action: m.Action.ValueStringPointer(),
-		Source: m.Source.ValueStringPointer(),
-		Value:  ExpandIpamsvcHostnameRewriteBlock(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_ip_space.go
+++ b/internal/service/ipam/model_ipamsvc_ip_space.go
@@ -10,6 +10,7 @@ import (
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -253,6 +254,9 @@ var IpamsvcIPSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 		Attributes: IpamsvcIPSpaceInheritanceResourceSchemaAttributes,
 		Optional:   true,
 		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"name": schema.StringAttribute{
 		Required:            true,

--- a/internal/service/ipam/model_ipamsvc_ip_space_inheritance.go
+++ b/internal/service/ipam/model_ipamsvc_ip_space_inheritance.go
@@ -56,70 +56,87 @@ var IpamsvcIPSpaceInheritanceResourceSchemaAttributes = map[string]schema.Attrib
 	"asm_config": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedASMConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_client_update": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_conflict_resolution_mode": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_enabled": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_hostname_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSHostnameBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_ttl_percent": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedFloatResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_update_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSUpdateBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_update_on_renew": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_use_conflict_resolution": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_options": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_options_v6": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_filename": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_address": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_name": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"hostname_rewrite_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedHostnameRewriteBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"vendor_specific_option_option_space": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedIdentifierResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_range.go
+++ b/internal/service/ipam/model_ipamsvc_range.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -141,6 +142,9 @@ var IpamsvcRangeResourceSchemaAttributes = map[string]schema.Attribute{
 		Attributes: IpamsvcDHCPOptionsInheritanceResourceSchemaAttributes,
 		Optional:   true,
 		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"name": schema.StringAttribute{
 		Optional: true,

--- a/internal/service/ipam/model_ipamsvc_server.go
+++ b/internal/service/ipam/model_ipamsvc_server.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -269,6 +271,9 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 		Attributes: IpamsvcServerInheritanceResourceSchemaAttributes,
 		Optional:   true,
 		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"kerberos_kdc": schema.StringAttribute{
 		Optional:            true,

--- a/internal/service/ipam/model_ipamsvc_server_inheritance.go
+++ b/internal/service/ipam/model_ipamsvc_server_inheritance.go
@@ -52,62 +52,77 @@ var IpamsvcServerInheritanceResourceSchemaAttributes = map[string]schema.Attribu
 	"ddns_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_client_update": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_conflict_resolution_mode": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_hostname_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDDNSHostnameBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_ttl_percent": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedFloatResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_update_on_renew": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"ddns_use_conflict_resolution": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedBoolResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPConfigResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_options": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"dhcp_options_v6": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedDHCPOptionListResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_filename": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_address": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"header_option_server_name": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedStringResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"hostname_rewrite_block": schema.SingleNestedAttribute{
 		Attributes: IpamsvcInheritedHostnameRewriteBlockResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 	"vendor_specific_option_option_space": schema.SingleNestedAttribute{
 		Attributes: InheritanceInheritedIdentifierResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
 	},
 }
 

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -12,6 +12,7 @@ import (
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -317,6 +318,10 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	"inheritance_sources": schema.SingleNestedAttribute{
 		Attributes: IpamsvcDHCPInheritanceResourceSchemaAttributes,
 		Optional:   true,
+		Computed:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"name": schema.StringAttribute{
 		Optional:            true,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,10 +1,13 @@
 package utils
 
 import (
+	"context"
 	"fmt"
+
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const ReadPageSizeLimit int32 = 1000
@@ -222,4 +225,100 @@ func ReadWithPages[T any](read func(offset, limit int32) ([]T, error)) ([]T, err
 	}
 
 	return allResults, nil
+}
+
+// ToComputedAttributeMap converts a map of resource schema attributes to schema attributes with all fields set to "computed".
+func ToComputedAttributeMap(r map[string]resourceschema.Attribute) map[string]resourceschema.Attribute {
+	d := map[string]resourceschema.Attribute{}
+	for k, v := range r {
+		d[k] = ToComputedAttribute(k, v)
+	}
+	return d
+}
+
+// ToComputedNestedAttributeObject converts a resource schema nested attribute object to nested attribute object with all fields set to "computed".
+func ToComputedNestedAttributeObject(r resourceschema.NestedAttributeObject) resourceschema.NestedAttributeObject {
+	return resourceschema.NestedAttributeObject{
+		Attributes: ToComputedAttributeMap(r.Attributes),
+		CustomType: r.CustomType,
+		Validators: r.Validators,
+	}
+}
+
+// ToComputedAttribute converts a resource schema attribute having all attributes set to "computed".
+func ToComputedAttribute(name string, val resourceschema.Attribute) resourceschema.Attribute {
+	switch a := val.(type) {
+	case resourceschema.StringAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.BoolAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.Int64Attribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.Float64Attribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.NumberAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.ObjectAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.ListAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.ListNestedAttribute:
+		a.NestedObject = ToComputedNestedAttributeObject(a.NestedObject)
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.MapAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.MapNestedAttribute:
+		a.NestedObject = ToComputedNestedAttributeObject(a.NestedObject)
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.SetAttribute:
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.SetNestedAttribute:
+		a.NestedObject = ToComputedNestedAttributeObject(a.NestedObject)
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	case resourceschema.SingleNestedAttribute:
+		a.Attributes = ToComputedAttributeMap(a.Attributes)
+		a.Required = false
+		a.Optional = false
+		a.Computed = true
+		return a
+	}
+
+	tflog.Error(context.Background(), fmt.Sprintf("Failed to convert schema attribute of type '%T' for '%s'", val, name))
+	return nil
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package objectplanmodifier provides plan modifiers for types.Object attributes.
+package objectplanmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Object {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.ObjectRequest, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Object {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyObject implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_configured.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Object {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.ObjectRequest, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/requires_replace_if_func.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.ObjectRequest, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier/use_state_for_unknown.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+func UseStateForUnknown() planmodifier.Object {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyObject implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,6 +185,7 @@ github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifie
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault
+github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier


### PR DESCRIPTION
- The inherited `value` for  inherited object models can have nested attributes that can be `Required` or just `Optional`. This causes an issue where the plan is always non-empty. https://github.com/hashicorp/terraform-plugin-framework/issues/898#issuecomment-1871470240 

- Created an util function to change all attributes as "Computed". 
- Updated the Inherited Object models to use the above function for `value` as the values are supposed to be read only anyway.
- Also updated the models to have Optional+Computed for inheritance_sources and attributes under it