### PR TITLE
Update pr-builder.yml

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -2,10 +2,6 @@
 name: PRBuilder
 on:
   pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
-      - 'examples/**'
 
 jobs:
   # ensure the code builds...


### PR DESCRIPTION
Remove the paths as we have 'Build' and 'Go Linter' as mandatory checks. The ignore path stops the workflow from running and results in the Checks waiting infinitely for the jobs to run.