### PR TITLE
fix: unable to unset optional string fields

### DIFF
--- a/docs/data-sources/dns_acls.md
+++ b/docs/data-sources/dns_acls.md
@@ -64,16 +64,6 @@ Read-Only:
 <a id="nestedatt--results--list"></a>
 ### Nested Schema for `results.list`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -85,12 +75,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--list--tsig_key))
 
 <a id="nestedatt--results--list--tsig_key"></a>
 ### Nested Schema for `results.list.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/data-sources/dns_auth_nsgs.md
+++ b/docs/data-sources/dns_auth_nsgs.md
@@ -85,7 +85,7 @@ Read-Only:
 <a id="nestedatt--results--external_primaries--tsig_key"></a>
 ### Nested Schema for `results.external_primaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -127,7 +127,7 @@ Read-Only:
 <a id="nestedatt--results--external_secondaries--tsig_key"></a>
 ### Nested Schema for `results.external_secondaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/data-sources/dns_auth_zones.md
+++ b/docs/data-sources/dns_auth_zones.md
@@ -107,7 +107,7 @@ Read-Only:
 <a id="nestedatt--results--external_primaries--tsig_key"></a>
 ### Nested Schema for `results.external_primaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -149,7 +149,7 @@ Read-Only:
 <a id="nestedatt--results--external_secondaries--tsig_key"></a>
 ### Nested Schema for `results.external_secondaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -595,16 +595,6 @@ Required:
 <a id="nestedatt--results--query_acl"></a>
 ### Nested Schema for `results.query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -616,12 +606,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--query_acl--tsig_key))
 
 <a id="nestedatt--results--query_acl--tsig_key"></a>
 ### Nested Schema for `results.query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -645,16 +642,6 @@ Read-Only:
 <a id="nestedatt--results--transfer_acl"></a>
 ### Nested Schema for `results.transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -666,12 +653,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--transfer_acl--tsig_key))
 
 <a id="nestedatt--results--transfer_acl--tsig_key"></a>
 ### Nested Schema for `results.transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -695,16 +689,6 @@ Read-Only:
 <a id="nestedatt--results--update_acl"></a>
 ### Nested Schema for `results.update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -716,12 +700,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--update_acl--tsig_key))
 
 <a id="nestedatt--results--update_acl--tsig_key"></a>
 ### Nested Schema for `results.update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/data-sources/dns_servers.md
+++ b/docs/data-sources/dns_servers.md
@@ -157,16 +157,6 @@ Read-Only:
 <a id="nestedatt--results--filter_aaaa_acl"></a>
 ### Nested Schema for `results.filter_aaaa_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -178,12 +168,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--filter_aaaa_acl--tsig_key))
 
 <a id="nestedatt--results--filter_aaaa_acl--tsig_key"></a>
 ### Nested Schema for `results.filter_aaaa_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1094,16 +1091,6 @@ Read-Only:
 <a id="nestedatt--results--query_acl"></a>
 ### Nested Schema for `results.query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1115,12 +1102,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--query_acl--tsig_key))
 
 <a id="nestedatt--results--query_acl--tsig_key"></a>
 ### Nested Schema for `results.query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1144,16 +1138,6 @@ Read-Only:
 <a id="nestedatt--results--recursion_acl"></a>
 ### Nested Schema for `results.recursion_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1165,12 +1149,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--recursion_acl--tsig_key))
 
 <a id="nestedatt--results--recursion_acl--tsig_key"></a>
 ### Nested Schema for `results.recursion_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1213,16 +1204,6 @@ Optional:
 <a id="nestedatt--results--transfer_acl"></a>
 ### Nested Schema for `results.transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1234,12 +1215,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--transfer_acl--tsig_key))
 
 <a id="nestedatt--results--transfer_acl--tsig_key"></a>
 ### Nested Schema for `results.transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1263,16 +1251,6 @@ Read-Only:
 <a id="nestedatt--results--update_acl"></a>
 ### Nested Schema for `results.update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1284,12 +1262,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--update_acl--tsig_key))
 
 <a id="nestedatt--results--update_acl--tsig_key"></a>
 ### Nested Schema for `results.update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/data-sources/dns_views.md
+++ b/docs/data-sources/dns_views.md
@@ -165,16 +165,6 @@ Read-Only:
 <a id="nestedatt--results--filter_aaaa_acl"></a>
 ### Nested Schema for `results.filter_aaaa_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -186,12 +176,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--filter_aaaa_acl--tsig_key))
 
 <a id="nestedatt--results--filter_aaaa_acl--tsig_key"></a>
 ### Nested Schema for `results.filter_aaaa_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1180,16 +1177,6 @@ Read-Only:
 <a id="nestedatt--results--match_clients_acl"></a>
 ### Nested Schema for `results.match_clients_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1201,12 +1188,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--match_clients_acl--tsig_key))
 
 <a id="nestedatt--results--match_clients_acl--tsig_key"></a>
 ### Nested Schema for `results.match_clients_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1230,16 +1224,6 @@ Read-Only:
 <a id="nestedatt--results--match_destinations_acl"></a>
 ### Nested Schema for `results.match_destinations_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1251,12 +1235,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--match_destinations_acl--tsig_key))
 
 <a id="nestedatt--results--match_destinations_acl--tsig_key"></a>
 ### Nested Schema for `results.match_destinations_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1280,16 +1271,6 @@ Read-Only:
 <a id="nestedatt--results--query_acl"></a>
 ### Nested Schema for `results.query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1301,12 +1282,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--query_acl--tsig_key))
 
 <a id="nestedatt--results--query_acl--tsig_key"></a>
 ### Nested Schema for `results.query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1330,16 +1318,6 @@ Read-Only:
 <a id="nestedatt--results--recursion_acl"></a>
 ### Nested Schema for `results.recursion_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1351,12 +1329,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--recursion_acl--tsig_key))
 
 <a id="nestedatt--results--recursion_acl--tsig_key"></a>
 ### Nested Schema for `results.recursion_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1399,16 +1384,6 @@ Optional:
 <a id="nestedatt--results--transfer_acl"></a>
 ### Nested Schema for `results.transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1420,12 +1395,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--transfer_acl--tsig_key))
 
 <a id="nestedatt--results--transfer_acl--tsig_key"></a>
 ### Nested Schema for `results.transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1449,16 +1431,6 @@ Read-Only:
 <a id="nestedatt--results--update_acl"></a>
 ### Nested Schema for `results.update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1470,12 +1442,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--results--update_acl--tsig_key))
 
 <a id="nestedatt--results--update_acl--tsig_key"></a>
 ### Nested Schema for `results.update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/resources/dns_acl.md
+++ b/docs/resources/dns_acl.md
@@ -51,16 +51,6 @@ resource "bloxone_dns_acl" "example_acl" {
 <a id="nestedatt--list"></a>
 ### Nested Schema for `list`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -72,12 +62,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--list--tsig_key))
 
 <a id="nestedatt--list--tsig_key"></a>
 ### Nested Schema for `list.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/resources/dns_auth_nsg.md
+++ b/docs/resources/dns_auth_nsg.md
@@ -79,7 +79,7 @@ Read-Only:
 <a id="nestedatt--external_primaries--tsig_key"></a>
 ### Nested Schema for `external_primaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -121,7 +121,7 @@ Read-Only:
 <a id="nestedatt--external_secondaries--tsig_key"></a>
 ### Nested Schema for `external_secondaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/resources/dns_auth_zone.md
+++ b/docs/resources/dns_auth_zone.md
@@ -137,7 +137,7 @@ Read-Only:
 <a id="nestedatt--external_primaries--tsig_key"></a>
 ### Nested Schema for `external_primaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -179,7 +179,7 @@ Read-Only:
 <a id="nestedatt--external_secondaries--tsig_key"></a>
 ### Nested Schema for `external_secondaries.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -625,16 +625,6 @@ Required:
 <a id="nestedatt--query_acl"></a>
 ### Nested Schema for `query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -646,12 +636,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--query_acl--tsig_key))
 
 <a id="nestedatt--query_acl--tsig_key"></a>
 ### Nested Schema for `query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -675,16 +672,6 @@ Read-Only:
 <a id="nestedatt--transfer_acl"></a>
 ### Nested Schema for `transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -696,12 +683,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--transfer_acl--tsig_key))
 
 <a id="nestedatt--transfer_acl--tsig_key"></a>
 ### Nested Schema for `transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -725,16 +719,6 @@ Read-Only:
 <a id="nestedatt--update_acl"></a>
 ### Nested Schema for `update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -746,12 +730,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--update_acl--tsig_key))
 
 <a id="nestedatt--update_acl--tsig_key"></a>
 ### Nested Schema for `update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/resources/dns_server.md
+++ b/docs/resources/dns_server.md
@@ -137,16 +137,6 @@ Read-Only:
 <a id="nestedatt--filter_aaaa_acl"></a>
 ### Nested Schema for `filter_aaaa_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -158,12 +148,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--filter_aaaa_acl--tsig_key))
 
 <a id="nestedatt--filter_aaaa_acl--tsig_key"></a>
 ### Nested Schema for `filter_aaaa_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1074,16 +1071,6 @@ Read-Only:
 <a id="nestedatt--query_acl"></a>
 ### Nested Schema for `query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1095,12 +1082,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--query_acl--tsig_key))
 
 <a id="nestedatt--query_acl--tsig_key"></a>
 ### Nested Schema for `query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1124,16 +1118,6 @@ Read-Only:
 <a id="nestedatt--recursion_acl"></a>
 ### Nested Schema for `recursion_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1145,12 +1129,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--recursion_acl--tsig_key))
 
 <a id="nestedatt--recursion_acl--tsig_key"></a>
 ### Nested Schema for `recursion_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1193,16 +1184,6 @@ Optional:
 <a id="nestedatt--transfer_acl"></a>
 ### Nested Schema for `transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1214,12 +1195,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--transfer_acl--tsig_key))
 
 <a id="nestedatt--transfer_acl--tsig_key"></a>
 ### Nested Schema for `transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1243,16 +1231,6 @@ Read-Only:
 <a id="nestedatt--update_acl"></a>
 ### Nested Schema for `update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1264,12 +1242,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--update_acl--tsig_key))
 
 <a id="nestedatt--update_acl--tsig_key"></a>
 ### Nested Schema for `update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/docs/resources/dns_view.md
+++ b/docs/resources/dns_view.md
@@ -203,16 +203,6 @@ Read-Only:
 <a id="nestedatt--filter_aaaa_acl"></a>
 ### Nested Schema for `filter_aaaa_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -224,12 +214,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--filter_aaaa_acl--tsig_key))
 
 <a id="nestedatt--filter_aaaa_acl--tsig_key"></a>
 ### Nested Schema for `filter_aaaa_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1218,16 +1215,6 @@ Read-Only:
 <a id="nestedatt--match_clients_acl"></a>
 ### Nested Schema for `match_clients_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1239,12 +1226,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--match_clients_acl--tsig_key))
 
 <a id="nestedatt--match_clients_acl--tsig_key"></a>
 ### Nested Schema for `match_clients_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1268,16 +1262,6 @@ Read-Only:
 <a id="nestedatt--match_destinations_acl"></a>
 ### Nested Schema for `match_destinations_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1289,12 +1273,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--match_destinations_acl--tsig_key))
 
 <a id="nestedatt--match_destinations_acl--tsig_key"></a>
 ### Nested Schema for `match_destinations_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1318,16 +1309,6 @@ Read-Only:
 <a id="nestedatt--query_acl"></a>
 ### Nested Schema for `query_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1339,12 +1320,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--query_acl--tsig_key))
 
 <a id="nestedatt--query_acl--tsig_key"></a>
 ### Nested Schema for `query_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1368,16 +1356,6 @@ Read-Only:
 <a id="nestedatt--recursion_acl"></a>
 ### Nested Schema for `recursion_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1389,12 +1367,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--recursion_acl--tsig_key))
 
 <a id="nestedatt--recursion_acl--tsig_key"></a>
 ### Nested Schema for `recursion_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1437,16 +1422,6 @@ Optional:
 <a id="nestedatt--transfer_acl"></a>
 ### Nested Schema for `transfer_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1458,12 +1433,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--transfer_acl--tsig_key))
 
 <a id="nestedatt--transfer_acl--tsig_key"></a>
 ### Nested Schema for `transfer_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 
@@ -1487,16 +1469,6 @@ Read-Only:
 <a id="nestedatt--update_acl"></a>
 ### Nested Schema for `update_acl`
 
-Required:
-
-- `element` (String) Type of element.
-
-  Allowed values:
-  * _any_
-  * _ip_
-  * _acl_
-  * _tsig_key_
-
 Optional:
 
 - `access` (String) Access permission for _element_.
@@ -1508,12 +1480,19 @@ Optional:
   Must be empty if _element_ is _acl_.
 - `acl` (String) The resource identifier.
 - `address` (String) Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.
+- `element` (String) Type of element.
+
+  Allowed values:
+  * _any_
+  * _ip_
+  * _acl_
+  * _tsig_key_
 - `tsig_key` (Attributes) (see [below for nested schema](#nestedatt--update_acl--tsig_key))
 
 <a id="nestedatt--update_acl--tsig_key"></a>
 ### Nested Schema for `update_acl.tsig_key`
 
-Required:
+Optional:
 
 - `key` (String) The resource identifier.
 

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -18,15 +18,24 @@ type FrameworkElementFlExFunc[T any, U any] func(context.Context, T, *diag.Diagn
 type FrameworkElementFlExFuncExt[T any, U any, V any] func(context.Context, T, U, *diag.Diagnostics) V
 
 func FlattenString(s string) types.String {
-	if s == "" {
-		return types.StringNull()
-	}
 	return types.StringValue(s)
 }
 
 func FlattenStringPointer(s *string) types.String {
 	if s == nil {
 		return types.StringNull()
+	}
+	return FlattenString(*s)
+}
+
+// FlattenStringPointerWithNilAsEmpty is a helper function to flatten a string pointer to a string.
+// It returns an empty string if the pointer is nil.
+//
+// For most fields, API returns empty string instead of null to signify no data, so use FlattenStringPointer instead.
+// In cases where the API returns null, use FlattenStringPointerWithNilAsEmpty.
+func FlattenStringPointerWithNilAsEmpty(s *string) types.String {
+	if s == nil {
+		return types.StringValue("")
 	}
 	return FlattenString(*s)
 }

--- a/internal/planmodifier/empty_string.go
+++ b/internal/planmodifier/empty_string.go
@@ -1,0 +1,38 @@
+package planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func UseEmptyStringForNull() planmodifier.String {
+	return useEmptyStringForNull{}
+}
+
+// useEmptyStringForNull implements the plan modifier.
+type useEmptyStringForNull struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useEmptyStringForNull) Description(_ context.Context) string {
+	return "Use an empty string for null values in the plan."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useEmptyStringForNull) MarkdownDescription(_ context.Context) string {
+	return "Use an empty string for null values in the plan."
+}
+
+// PlanModifyString implements the plan modification logic.
+func (m useEmptyStringForNull) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// If the config value is unknown or null, use an empty string.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		resp.PlanValue = types.StringValue("")
+	}
+}

--- a/internal/service/dns_config/default_acl_plan_modifier.go
+++ b/internal/service/dns_config/default_acl_plan_modifier.go
@@ -1,0 +1,58 @@
+package dns_config
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func UseDefaultAclForNull() planmodifier.List {
+	return useDefaultAclForNull{}
+}
+
+// useDefaultAclForNull implements the plan modifier.
+type useDefaultAclForNull struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useDefaultAclForNull) Description(_ context.Context) string {
+	return "Sets the default value for the acl attribute in the plan if the value is null."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useDefaultAclForNull) MarkdownDescription(_ context.Context) string {
+	return "Sets the default value for the acl attribute in the plan if the value is null."
+}
+
+// PlanModifyList implements the plan modification logic.
+func (m useDefaultAclForNull) PlanModifyList(ctx context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// If the config value is unknown or null, use an empty string.
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		obj, diags := types.ObjectValue(ConfigACLItemAttrTypes, map[string]attr.Value{
+			"access":   types.StringValue("allow"),
+			"acl":      types.StringNull(),
+			"address":  types.StringValue(""),
+			"element":  types.StringValue("any"),
+			"tsig_key": types.ObjectNull(ConfigTSIGKeyAttrTypes),
+		})
+		if resp.Diagnostics = append(resp.Diagnostics, diags...); resp.Diagnostics.HasError() {
+			return
+		}
+
+		resp.PlanValue, diags = types.ListValue(types.ObjectType{
+			AttrTypes: ConfigACLItemAttrTypes,
+		}, []attr.Value{
+			obj,
+		})
+		if resp.Diagnostics = append(resp.Diagnostics, diags...); resp.Diagnostics.HasError() {
+			return
+		}
+
+	}
+}

--- a/internal/service/dns_config/model_config_acl.go
+++ b/internal/service/dns_config/model_config_acl.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -35,6 +36,8 @@ var ConfigACLAttrTypes = map[string]attr.Type{
 var ConfigACLResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `Optional. Comment for ACL.`,
 	},
 	"id": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_acl_item.go
+++ b/internal/service/dns_config/model_config_acl_item.go
@@ -3,15 +3,20 @@ package dns_config
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	internalvalidator "github.com/infobloxopen/terraform-provider-bloxone/internal/validator"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
+	internalplanmodifier "github.com/infobloxopen/terraform-provider-bloxone/internal/planmodifier"
 )
 
 type ConfigACLItemModel struct {
@@ -33,6 +38,10 @@ var ConfigACLItemAttrTypes = map[string]attr.Type{
 var ConfigACLItemResourceSchemaAttributes = map[string]schema.Attribute{
 	"access": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			internalplanmodifier.UseEmptyStringForNull(),
+		},
 		MarkdownDescription: "Access permission for _element_.\n\n" +
 			"  Allowed values:\n" +
 			"  * _allow_\n" +
@@ -44,11 +53,20 @@ var ConfigACLItemResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"address": schema.StringAttribute{
-		Optional:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			internalplanmodifier.UseEmptyStringForNull(),
+		},
 		MarkdownDescription: `Optional. Data for _ip_ _element_.  Must be empty if _element_ is not _ip_.`,
 	},
 	"element": schema.StringAttribute{
-		Required: true,
+		Optional: true,
+		Computed: true,
+		Validators: []validator.String{
+			internalvalidator.StringNotNull(),
+			stringvalidator.OneOf("any", "ip", "acl", "tsig_key"),
+		},
 		MarkdownDescription: "Type of element.\n\n" +
 			"  Allowed values:\n" +
 			"  * _any_\n" +

--- a/internal/service/dns_config/model_config_auth_nsg.go
+++ b/internal/service/dns_config/model_config_auth_nsg.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -41,6 +42,8 @@ var ConfigAuthNSGAttrTypes = map[string]attr.Type{
 var ConfigAuthNSGResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. Comment for the object.",
 	},
 	"external_primaries": schema.ListNestedAttribute{

--- a/internal/service/dns_config/model_config_auth_zone.go
+++ b/internal/service/dns_config/model_config_auth_zone.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -88,6 +89,8 @@ var ConfigAuthZoneAttrTypes = map[string]attr.Type{
 var ConfigAuthZoneResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `Optional. Comment for zone configuration.`,
 	},
 	"created_at": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_delegation.go
+++ b/internal/service/dns_config/model_config_delegation.go
@@ -2,9 +2,11 @@ package dns_config
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
@@ -46,6 +48,8 @@ var ConfigDelegationAttrTypes = map[string]attr.Type{
 var ConfigDelegationResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. Comment for zone delegation.",
 	},
 	"delegation_servers": schema.ListNestedAttribute{

--- a/internal/service/dns_config/model_config_external_primary.go
+++ b/internal/service/dns_config/model_config_external_primary.go
@@ -7,10 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	internalplanmodifier "github.com/infobloxopen/terraform-provider-bloxone/internal/planmodifier"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -37,11 +39,19 @@ var ConfigExternalPrimaryAttrTypes = map[string]attr.Type{
 
 var ConfigExternalPrimaryResourceSchemaAttributes = map[string]schema.Attribute{
 	"address": schema.StringAttribute{
-		Optional:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			internalplanmodifier.UseEmptyStringForNull(),
+		},
 		MarkdownDescription: `Optional. Required only if _type_ is _server_. IP Address of nameserver.`,
 	},
 	"fqdn": schema.StringAttribute{
-		Optional:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			internalplanmodifier.UseEmptyStringForNull(),
+		},
 		MarkdownDescription: `Optional. Required only if _type_ is _server_. FQDN of nameserver.`,
 	},
 	"nsg": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_forward_nsg.go
+++ b/internal/service/dns_config/model_config_forward_nsg.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -45,6 +46,8 @@ var ConfigForwardNSGAttrTypes = map[string]attr.Type{
 var ConfigForwardNSGResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. Comment for the object.",
 	},
 	"external_forwarders": schema.ListNestedAttribute{

--- a/internal/service/dns_config/model_config_forward_zone.go
+++ b/internal/service/dns_config/model_config_forward_zone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -63,6 +64,8 @@ var ConfigForwardZoneAttrTypes = map[string]attr.Type{
 var ConfigForwardZoneResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. Comment for zone configuration.",
 	},
 	"created_at": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_server.go
+++ b/internal/service/dns_config/model_config_server.go
@@ -140,6 +140,8 @@ var ConfigServerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. Comment for configuration.",
 	},
 	"created_at": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_sort_list_item.go
+++ b/internal/service/dns_config/model_config_sort_list_item.go
@@ -6,10 +6,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
+	internalplanmodifier "github.com/infobloxopen/terraform-provider-bloxone/internal/planmodifier"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
@@ -47,7 +49,11 @@ var ConfigSortListItemResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: `Optional. The prioritized networks. If empty, the value of _source_ or networks from _acl_ is used.`,
 	},
 	"source": schema.StringAttribute{
-		Optional:            true,
+		Optional: true,
+		Computed: true,
+		PlanModifiers: []planmodifier.String{
+			internalplanmodifier.UseEmptyStringForNull(),
+		},
 		MarkdownDescription: `Must be empty if _element_ is not _ip_.`,
 	},
 }

--- a/internal/service/dns_config/model_config_tsig_key.go
+++ b/internal/service/dns_config/model_config_tsig_key.go
@@ -6,12 +6,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dns_config"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
+	internalvalidator "github.com/infobloxopen/terraform-provider-bloxone/internal/validator"
 )
 
 type ConfigTSIGKeyModel struct {
@@ -48,7 +50,11 @@ var ConfigTSIGKeyResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: `Comment for TSIG key.`,
 	},
 	"key": schema.StringAttribute{
-		Required:            true,
+		Optional: true,
+		Computed: true,
+		Validators: []validator.String{
+			internalvalidator.StringNotNull(),
+		},
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"name": schema.StringAttribute{

--- a/internal/service/dns_config/model_config_view.go
+++ b/internal/service/dns_config/model_config_view.go
@@ -10,7 +10,6 @@ import (
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -24,14 +23,6 @@ import (
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
-
-var aclDefaultValues = map[string]attr.Value{
-	"access":   types.StringValue("allow"),
-	"acl":      types.StringNull(),
-	"address":  types.StringNull(),
-	"element":  types.StringValue("any"),
-	"tsig_key": types.ObjectNull(ConfigTSIGKeyAttrTypes),
-}
 
 type ConfigViewModel struct {
 	AddEdnsOptionInOutgoingQuery                types.Bool        `tfsdk:"add_edns_option_in_outgoing_query"`
@@ -144,6 +135,8 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `Optional. Comment for view.`,
 	},
 	"created_at": schema.StringAttribute{
@@ -319,9 +312,9 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 		Optional: true,
 		Computed: true,
-		Default: listdefault.StaticValue(types.ListValueMust(types.ObjectType{AttrTypes: ConfigACLItemAttrTypes}, []attr.Value{
-			types.ObjectValueMust(ConfigACLItemAttrTypes, aclDefaultValues),
-		})),
+		PlanModifiers: []planmodifier.List{
+			UseDefaultAclForNull(),
+		},
 		MarkdownDescription: `Optional. Specifies which clients have access to the view.  Defaults to empty.`,
 	},
 	"match_destinations_acl": schema.ListNestedAttribute{
@@ -330,9 +323,9 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 		Optional: true,
 		Computed: true,
-		Default: listdefault.StaticValue(types.ListValueMust(types.ObjectType{AttrTypes: ConfigACLItemAttrTypes}, []attr.Value{
-			types.ObjectValueMust(ConfigACLItemAttrTypes, aclDefaultValues),
-		})),
+		PlanModifiers: []planmodifier.List{
+			UseDefaultAclForNull(),
+		},
 		MarkdownDescription: `Optional. Specifies which destination addresses have access to the view.  Defaults to empty.`,
 	},
 	"match_recursive_only": schema.BoolAttribute{
@@ -451,6 +444,9 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 		Attributes: ConfigZoneAuthorityResourceSchemaAttributes,
 		Computed:   true,
 		Optional:   true,
+		PlanModifiers: []planmodifier.Object{
+			objectplanmodifier.UseStateForUnknown(),
+		},
 		Default: objectdefault.StaticValue(types.ObjectValueMust(ConfigZoneAuthorityAttrTypes, map[string]attr.Value{
 			"default_ttl":       types.Int64Value(28800),
 			"expire":            types.Int64Value(2.4192e+06),

--- a/internal/service/dns_data/model_data_record.go
+++ b/internal/service/dns_data/model_data_record.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -97,6 +98,8 @@ func recordCommonSchema() map[string]schema.Attribute {
 		},
 		"comment": schema.StringAttribute{
 			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString(""),
 			MarkdownDescription: "The description for the DNS resource record. May contain 0 to 1024 characters. Can include UTF-8.",
 		},
 		"created_at": schema.StringAttribute{

--- a/internal/service/dns_data/record_caa.go
+++ b/internal/service/dns_data/record_caa.go
@@ -99,7 +99,11 @@ func flattenRDataFieldString(val interface{}, diags *diag.Diagnostics) basetypes
 		diags.AddError("Value conversion error", fmt.Sprintf("Failed to convert value '%v' to string", val))
 		return types.StringNull()
 	}
-
+	if val.(string) == "" {
+		// rdata is sent as a map, so we need to return a null value if the string is empty
+		// if the empty string is significant, this can be wrapped around a emptyAsNull flag
+		return types.StringNull()
+	}
 	return flex.FlattenString(val.(string))
 }
 

--- a/internal/service/ipam/model_ipamsvc_address.go
+++ b/internal/service/ipam/model_ipamsvc_address.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -79,6 +80,8 @@ var IpamsvcAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the address object. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{
@@ -110,6 +113,8 @@ var IpamsvcAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"hwaddr": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The hardware address associated with this IP address.",
 	},
 	"id": schema.StringAttribute{
@@ -121,6 +126,8 @@ var IpamsvcAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"interface": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The name of the network interface card (NIC) associated with the address, if any.",
 	},
 	"names": schema.ListNestedAttribute{

--- a/internal/service/ipam/model_ipamsvc_address_block.go
+++ b/internal/service/ipam/model_ipamsvc_address_block.go
@@ -150,6 +150,8 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the address block. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{
@@ -180,8 +182,11 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ddns_domain": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The domain suffix for DDNS updates. FQDN, may be empty.  Defaults to empty.",
 	},
+
 	"ddns_generate_name": schema.BoolAttribute{
 		Optional:            true,
 		Computed:            true,
@@ -258,14 +263,20 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"header_option_filename": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option filename field.",
 	},
 	"header_option_server_address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server address field.",
 	},
 	"header_option_server_name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server name field.",
 	},
 	"hostname_rewrite_char": schema.StringAttribute{
@@ -308,6 +319,8 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The name of the address block. May contain 1 to 256 characters. Can include UTF-8.",
 	},
 	"parent": schema.StringAttribute{

--- a/internal/service/ipam/model_ipamsvc_exclusion_range.go
+++ b/internal/service/ipam/model_ipamsvc_exclusion_range.go
@@ -2,7 +2,9 @@ package ipam
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -31,6 +33,8 @@ var IpamsvcExclusionRangeAttrTypes = map[string]attr.Type{
 var IpamsvcExclusionRangeResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},

--- a/internal/service/ipam/model_ipamsvc_fixed_address.go
+++ b/internal/service/ipam/model_ipamsvc_fixed_address.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -84,6 +85,8 @@ var IpamsvcFixedAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the fixed address. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{
@@ -106,18 +109,26 @@ var IpamsvcFixedAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"header_option_filename": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option filename field.",
 	},
 	"header_option_server_address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server address field.",
 	},
 	"header_option_server_name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server name field.",
 	},
 	"hostname": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The DHCP host name associated with this fixed address. It is of FQDN type and it defaults to empty.",
 	},
 	"id": schema.StringAttribute{
@@ -168,6 +179,8 @@ var IpamsvcFixedAddressResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The name of the fixed address. May contain 1 to 256 characters. Can include UTF-8.",
 	},
 	"parent": schema.StringAttribute{

--- a/internal/service/ipam/model_ipamsvc_ha_group.go
+++ b/internal/service/ipam/model_ipamsvc_ha_group.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
@@ -58,6 +59,8 @@ var IpamsvcHAGroupResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},

--- a/internal/service/ipam/model_ipamsvc_ip_space.go
+++ b/internal/service/ipam/model_ipamsvc_ip_space.go
@@ -116,6 +116,8 @@ var IpamsvcIPSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The description for the IP space. May contain 0 to 1024 characters. Can include UTF-8.`,
 	},
 	"created_at": schema.StringAttribute{
@@ -154,6 +156,8 @@ var IpamsvcIPSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ddns_domain": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The domain suffix for DDNS updates. FQDN, may be empty.  Defaults to empty.`,
 	},
 	"ddns_generate_name": schema.BoolAttribute{
@@ -223,14 +227,20 @@ var IpamsvcIPSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"header_option_filename": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The configuration for header option filename field.`,
 	},
 	"header_option_server_address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The configuration for header option server address field.`,
 	},
 	"header_option_server_name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The configuration for header option server name field.`,
 	},
 	"hostname_rewrite_char": schema.StringAttribute{
@@ -319,7 +329,7 @@ func (m *IpamsvcIPSpaceModel) Expand(ctx context.Context, diags *diag.Diagnostic
 	}
 	to := &ipam.IpamsvcIPSpace{
 		AsmConfig:                       ExpandIpamsvcASMConfig(ctx, m.AsmConfig, diags),
-		Comment:                         m.Comment.ValueStringPointer(),
+		Comment:                         flex.ExpandStringPointer(m.Comment),
 		DdnsClientUpdate:                m.DdnsClientUpdate.ValueStringPointer(),
 		DdnsConflictResolutionMode:      m.DdnsConflictResolutionMode.ValueStringPointer(),
 		DdnsDomain:                      m.DdnsDomain.ValueStringPointer(),

--- a/internal/service/ipam/model_ipamsvc_ipam_host.go
+++ b/internal/service/ipam/model_ipamsvc_ipam_host.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -63,6 +64,8 @@ var IpamsvcIpamHostResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: `The description for the IPAM host. May contain 0 to 1024 characters. Can include UTF-8.`,
 	},
 	"created_at": schema.StringAttribute{

--- a/internal/service/ipam/model_ipamsvc_option_code.go
+++ b/internal/service/ipam/model_ipamsvc_option_code.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -59,6 +60,8 @@ var IpamsvcOptionCodeResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},

--- a/internal/service/ipam/model_ipamsvc_option_group.go
+++ b/internal/service/ipam/model_ipamsvc_option_group.go
@@ -9,9 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/infobloxopen/bloxone-go-client/ipam"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
@@ -42,6 +44,8 @@ var IpamsvcOptionGroupAttrTypes = map[string]attr.Type{
 var IpamsvcOptionGroupResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},

--- a/internal/service/ipam/model_ipamsvc_option_item.go
+++ b/internal/service/ipam/model_ipamsvc_option_item.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -35,19 +36,21 @@ var IpamsvcOptionItemResourceSchemaAttributes = map[string]schema.Attribute{
 	"group": schema.StringAttribute{
 		Optional: true,
 		Validators: []validator.String{
-			stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("option_code")),
+			stringvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("option_code"), path.MatchRelative().AtParent().AtName("group")),
 		},
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"option_code": schema.StringAttribute{
 		Optional: true,
 		Validators: []validator.String{
-			stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("group")),
+			stringvalidator.ExactlyOneOf(path.MatchRelative().AtParent().AtName("option_code"), path.MatchRelative().AtParent().AtName("group")),
 		},
 		MarkdownDescription: `The resource identifier.`,
 	},
 	"option_value": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.AlsoRequires(path.MatchRelative().AtParent().AtName("option_code")),
 		},

--- a/internal/service/ipam/model_ipamsvc_option_space.go
+++ b/internal/service/ipam/model_ipamsvc_option_space.go
@@ -9,9 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
 	"github.com/infobloxopen/bloxone-go-client/ipam"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
@@ -40,6 +42,8 @@ var IpamsvcOptionSpaceAttrTypes = map[string]attr.Type{
 var IpamsvcOptionSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},

--- a/internal/service/ipam/model_ipamsvc_range.go
+++ b/internal/service/ipam/model_ipamsvc_range.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -74,6 +75,8 @@ var IpamsvcRangeAttrTypes = map[string]attr.Type{
 var IpamsvcRangeResourceSchemaAttributes = map[string]schema.Attribute{
 	"comment": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(0, 1024),
 		},
@@ -87,6 +90,7 @@ var IpamsvcRangeResourceSchemaAttributes = map[string]schema.Attribute{
 	"dhcp_host": schema.StringAttribute{
 		Optional:            true,
 		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The resource identifier.",
 	},
 	"dhcp_options": schema.ListNestedAttribute{
@@ -148,6 +152,8 @@ var IpamsvcRangeResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"name": schema.StringAttribute{
 		Optional: true,
+		Computed: true,
+		Default:  stringdefault.StaticString(""),
 		Validators: []validator.String{
 			stringvalidator.LengthBetween(1, 256),
 		},
@@ -256,7 +262,7 @@ func (m *IpamsvcRangeModel) Flatten(ctx context.Context, from *ipam.IpamsvcRange
 	}
 	m.Comment = flex.FlattenStringPointer(from.Comment)
 	m.CreatedAt = timetypes.NewRFC3339TimePointerValue(from.CreatedAt)
-	m.DhcpHost = flex.FlattenStringPointer(from.DhcpHost)
+	m.DhcpHost = flex.FlattenStringPointerWithNilAsEmpty(from.DhcpHost)
 	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DisableDhcp = types.BoolPointerValue(from.DisableDhcp)
 	m.End = flex.FlattenString(from.End)

--- a/internal/service/ipam/model_ipamsvc_server.go
+++ b/internal/service/ipam/model_ipamsvc_server.go
@@ -107,10 +107,14 @@ var IpamsvcServerAttrTypes = map[string]attr.Type{
 var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 	"client_principal": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The Kerberos principal name. It uses the typical Kerberos notation: `<SERVICE-NAME>/<server-domain-name>@<REALM>`. Defaults to empty.",
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the DHCP Config Profile. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{
@@ -149,6 +153,8 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ddns_domain": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The domain suffix for DDNS updates. FQDN, may be empty. Required if _ddns_enabled_ is true.  Defaults to empty.",
 	},
 	"ddns_enabled": schema.BoolAttribute{
@@ -240,14 +246,20 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"header_option_filename": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option filename field.",
 	},
 	"header_option_server_address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server address field.",
 	},
 	"header_option_server_name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server name field.",
 	},
 	"hostname_rewrite_char": schema.StringAttribute{
@@ -288,6 +300,8 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"kerberos_kdc": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Address of Kerberos Key Distribution Center.  Defaults to empty.",
 	},
 	"kerberos_keys": schema.ListNestedAttribute{
@@ -326,6 +340,8 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"server_principal": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The Kerberos principal name of the external DNS server that will receive updates.  Defaults to empty.",
 	},
 	"tags": schema.MapAttribute{

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -159,6 +159,8 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the subnet. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{
@@ -194,6 +196,8 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"ddns_domain": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The domain suffix for DDNS updates. FQDN, may be empty.  Defaults to empty.",
 	},
 	"ddns_generate_name": schema.BoolAttribute{
@@ -249,6 +253,8 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"dhcp_host": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The resource identifier.",
 	},
 	"dhcp_options": schema.ListNestedAttribute{
@@ -280,14 +286,20 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"header_option_filename": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option filename field.",
 	},
 	"header_option_server_address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server address field.",
 	},
 	"header_option_server_name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The configuration for header option server name field.",
 	},
 	"hostname_rewrite_char": schema.StringAttribute{
@@ -336,6 +348,8 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"name": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The name of the subnet. May contain 1 to 256 characters. Can include UTF-8.",
 	},
 	"parent": schema.StringAttribute{
@@ -492,7 +506,7 @@ func (m *IpamsvcSubnetModel) Flatten(ctx context.Context, from *ipam.IpamsvcSubn
 	m.DdnsUpdateOnRenew = types.BoolPointerValue(from.DdnsUpdateOnRenew)
 	m.DdnsUseConflictResolution = types.BoolPointerValue(from.DdnsUseConflictResolution)
 	m.DhcpConfig = FlattenIpamsvcDHCPConfig(ctx, from.DhcpConfig, diags)
-	m.DhcpHost = flex.FlattenStringPointer(from.DhcpHost)
+	m.DhcpHost = flex.FlattenStringPointerWithNilAsEmpty(from.DhcpHost)
 	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DhcpUtilization = FlattenIpamsvcDHCPUtilization(ctx, from.DhcpUtilization, diags)
 	m.DisableDhcp = types.BoolPointerValue(from.DisableDhcp)

--- a/internal/service/keys/model_keys_tsig_key.go
+++ b/internal/service/keys/model_keys_tsig_key.go
@@ -63,6 +63,8 @@ var KeysTSIGKeyResourceSchemaAttributes = map[string]schema.Attribute{
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "The description for the TSIG key. May contain 0 to 1024 characters. Can include UTF-8.",
 	},
 	"created_at": schema.StringAttribute{

--- a/internal/validator/string_not_null.go
+++ b/internal/validator/string_not_null.go
@@ -12,8 +12,7 @@ var _ validator.String = stringNotNullValidator{}
 // stringNotNullValidator validates that the value is not null.
 // This is required for some fields that are "required" but cannot be marked required in the schema.
 // See - https://github.com/hashicorp/terraform-plugin-framework/issues/898#issuecomment-1871470240
-type stringNotNullValidator struct {
-}
+type stringNotNullValidator struct {}
 
 func (s stringNotNullValidator) Description(ctx context.Context) string {
 	return "string must not be null"

--- a/internal/validator/string_not_null.go
+++ b/internal/validator/string_not_null.go
@@ -1,0 +1,38 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = stringNotNullValidator{}
+
+// stringNotNullValidator validates that the value is not null.
+// This is required for some fields that are "required" but cannot be marked required in the schema.
+// See - https://github.com/hashicorp/terraform-plugin-framework/issues/898#issuecomment-1871470240
+type stringNotNullValidator struct {
+}
+
+func (s stringNotNullValidator) Description(ctx context.Context) string {
+	return "string must not be null"
+}
+
+func (s stringNotNullValidator) MarkdownDescription(ctx context.Context) string {
+	return "string must not be null"
+}
+
+func (s stringNotNullValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueLengthDiagnostic(
+			request.Path,
+			s.Description(ctx),
+			"null",
+		))
+	}
+}
+
+func StringNotNull() validator.String {
+	return stringNotNullValidator{}
+}


### PR DESCRIPTION
- Changed flatten function to consider empty string as it is, instead of considering as null. 
- Changed most optional string fields to have default value as an empty string
- Added a plan modifier to apply for fields that are part of lists, where adding defaults causes other issues. 
- Added a plan modifier to have the default acl value for view.
- Changed tsig_key.key and acl_item.element to be optional+computed instead of required. This is done because of an existing bug with the plugin framework where having a required inside a list causes non empty plan even if there is no changes. Added a not null validator to ensure that the required constraint is still met.