### PR TITLE
fix: subnet creation fails because echo_client_id is not allowed for subnet

### DIFF
--- a/docs/data-sources/ipam_address_blocks.md
+++ b/docs/data-sources/ipam_address_blocks.md
@@ -138,17 +138,20 @@ Optional:
 
 Optional:
 
-- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
-- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
 - `allow_unknown` (Boolean) Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
 - `allow_unknown_v6` (Boolean) Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
-- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 - `filters` (List of String) The resource identifier.
 - `filters_v6` (List of String) The resource identifier.
 - `ignore_client_uid` (Boolean) Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
 - `ignore_list` (Attributes List) The list of clients to ignore requests from. (see [below for nested schema](#nestedatt--results--dhcp_config--ignore_list))
 - `lease_time` (Number) The lease duration in seconds.
 - `lease_time_v6` (Number) The lease duration in seconds for IPV6 clients.
+
+Read-Only:
+
+- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
+- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
+- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 
 <a id="nestedatt--results--dhcp_config--ignore_list"></a>
 ### Nested Schema for `results.dhcp_config.ignore_list`

--- a/docs/data-sources/ipam_subnets.md
+++ b/docs/data-sources/ipam_subnets.md
@@ -145,17 +145,20 @@ Optional:
 
 Optional:
 
-- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
-- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
 - `allow_unknown` (Boolean) Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
 - `allow_unknown_v6` (Boolean) Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
-- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 - `filters` (List of String) The resource identifier.
 - `filters_v6` (List of String) The resource identifier.
 - `ignore_client_uid` (Boolean) Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
 - `ignore_list` (Attributes List) The list of clients to ignore requests from. (see [below for nested schema](#nestedatt--results--dhcp_config--ignore_list))
 - `lease_time` (Number) The lease duration in seconds.
 - `lease_time_v6` (Number) The lease duration in seconds for IPV6 clients.
+
+Read-Only:
+
+- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
+- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
+- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 
 <a id="nestedatt--results--dhcp_config--ignore_list"></a>
 ### Nested Schema for `results.dhcp_config.ignore_list`

--- a/docs/resources/ipam_address_block.md
+++ b/docs/resources/ipam_address_block.md
@@ -223,17 +223,20 @@ Optional:
 
 Optional:
 
-- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
-- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
 - `allow_unknown` (Boolean) Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
 - `allow_unknown_v6` (Boolean) Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
-- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 - `filters` (List of String) The resource identifier.
 - `filters_v6` (List of String) The resource identifier.
 - `ignore_client_uid` (Boolean) Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
 - `ignore_list` (Attributes List) The list of clients to ignore requests from. (see [below for nested schema](#nestedatt--dhcp_config--ignore_list))
 - `lease_time` (Number) The lease duration in seconds.
 - `lease_time_v6` (Number) The lease duration in seconds for IPV6 clients.
+
+Read-Only:
+
+- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
+- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
+- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 
 <a id="nestedatt--dhcp_config--ignore_list"></a>
 ### Nested Schema for `dhcp_config.ignore_list`

--- a/docs/resources/ipam_subnet.md
+++ b/docs/resources/ipam_subnet.md
@@ -167,17 +167,20 @@ Optional:
 
 Optional:
 
-- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
-- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
 - `allow_unknown` (Boolean) Disable to allow leases only for known IPv4 clients, those for which a fixed address is configured.
 - `allow_unknown_v6` (Boolean) Disable to allow leases only for known IPV6 clients, those for which a fixed address is configured.
-- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 - `filters` (List of String) The resource identifier.
 - `filters_v6` (List of String) The resource identifier.
 - `ignore_client_uid` (Boolean) Enable to ignore the client UID when issuing a DHCP lease. Use this option to prevent assigning two IP addresses for a client which does not have a UID during one phase of PXE boot but acquires one for the other phase.
 - `ignore_list` (Attributes List) The list of clients to ignore requests from. (see [below for nested schema](#nestedatt--dhcp_config--ignore_list))
 - `lease_time` (Number) The lease duration in seconds.
 - `lease_time_v6` (Number) The lease duration in seconds for IPV6 clients.
+
+Read-Only:
+
+- `abandoned_reclaim_time` (Number) The abandoned reclaim time in seconds for IPV4 clients.
+- `abandoned_reclaim_time_v6` (Number) The abandoned reclaim time in seconds for IPV6 clients.
+- `echo_client_id` (Boolean) Enable/disable to include/exclude the client id when responding to discover or request.
 
 <a id="nestedatt--dhcp_config--ignore_list"></a>
 ### Nested Schema for `dhcp_config.ignore_list`

--- a/internal/service/ipam/model_ipamsvc_address_block.go
+++ b/internal/service/ipam/model_ipamsvc_address_block.go
@@ -221,15 +221,15 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.  When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.  Defaults to _true_.",
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes,
+		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes(true),
 		Optional:   true,
 		Computed:   true,
 		Default: objectdefault.StaticValue(types.ObjectValueMust(IpamsvcDHCPConfigAttrTypes, map[string]attr.Value{
-			"abandoned_reclaim_time":    types.Int64Null(),
-			"abandoned_reclaim_time_v6": types.Int64Null(),
+			"abandoned_reclaim_time":    types.Int64Null(), // abandonded_reclaim_time cannot be set for address block
+			"abandoned_reclaim_time_v6": types.Int64Null(), // abandonded_reclaim_time_v6 cannot be set for address block
 			"allow_unknown":             types.BoolValue(true),
 			"allow_unknown_v6":          types.BoolValue(true),
-			"echo_client_id":            types.BoolValue(false),
+			"echo_client_id":            types.BoolNull(), // echo_client_id cannot be set for address block
 			"filters":                   types.ListNull(types.StringType),
 			"filters_v6":                types.ListNull(types.StringType),
 			"ignore_client_uid":         types.BoolValue(false),
@@ -481,7 +481,7 @@ func (m *IpamsvcAddressBlockModel) Flatten(ctx context.Context, from *ipam.Ipams
 	m.DdnsTtlPercent = flex.FlattenFloat64(float64(*from.DdnsTtlPercent))
 	m.DdnsUpdateOnRenew = types.BoolPointerValue(from.DdnsUpdateOnRenew)
 	m.DdnsUseConflictResolution = types.BoolPointerValue(from.DdnsUseConflictResolution)
-	m.DhcpConfig = FlattenIpamsvcDHCPConfig(ctx, from.DhcpConfig, diags)
+	m.DhcpConfig = FlattenIpamsvcDHCPConfigForSubnetOrAddressBlock(ctx, from.DhcpConfig, diags)
 	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DhcpUtilization = FlattenIpamsvcDHCPUtilization(ctx, from.DhcpUtilization, diags)
 	m.DiscoveryAttrs = flex.FlattenFrameworkMapString(ctx, from.DiscoveryAttrs, diags)

--- a/internal/service/ipam/model_ipamsvc_ip_space.go
+++ b/internal/service/ipam/model_ipamsvc_ip_space.go
@@ -195,7 +195,7 @@ var IpamsvcIPSpaceResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: `When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.  When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.  Defaults to _true_.`,
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes,
+		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes(false),
 		Optional:   true,
 		Computed:   true,
 		Default: objectdefault.StaticValue(types.ObjectValueMust(IpamsvcDHCPConfigAttrTypes, map[string]attr.Value{

--- a/internal/service/ipam/model_ipamsvc_server.go
+++ b/internal/service/ipam/model_ipamsvc_server.go
@@ -208,7 +208,7 @@ var IpamsvcServerResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes,
+		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes(false),
 		Optional:   true,
 		Computed:   true,
 		Default: objectdefault.StaticValue(types.ObjectValueMust(IpamsvcDHCPConfigAttrTypes, map[string]attr.Value{

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -235,15 +235,15 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "When true, DHCP server will apply conflict resolution, as described in RFC 4703, when attempting to fulfill the update request.  When false, DHCP server will simply attempt to update the DNS entries per the request, regardless of whether or not they conflict with existing entries owned by other DHCP4 clients.  Defaults to _true_.",
 	},
 	"dhcp_config": schema.SingleNestedAttribute{
-		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes,
+		Attributes: IpamsvcDHCPConfigResourceSchemaAttributes(true),
 		Optional:   true,
 		Computed:   true,
 		Default: objectdefault.StaticValue(types.ObjectValueMust(IpamsvcDHCPConfigAttrTypes, map[string]attr.Value{
-			"abandoned_reclaim_time":    types.Int64Null(),
-			"abandoned_reclaim_time_v6": types.Int64Null(),
+			"abandoned_reclaim_time":    types.Int64Null(), // abandoned_reclaim_time cannot be set for subnet
+			"abandoned_reclaim_time_v6": types.Int64Null(), // abandoned_reclaim_time_v6 cannot be set for subnet
 			"allow_unknown":             types.BoolValue(true),
 			"allow_unknown_v6":          types.BoolValue(true),
-			"echo_client_id":            types.BoolValue(false),
+			"echo_client_id":            types.BoolNull(), // echo_id cannot be set for subnet
 			"filters":                   types.ListNull(types.StringType),
 			"filters_v6":                types.ListNull(types.StringType),
 			"ignore_client_uid":         types.BoolValue(false),
@@ -506,7 +506,7 @@ func (m *IpamsvcSubnetModel) Flatten(ctx context.Context, from *ipam.IpamsvcSubn
 	m.DdnsTtlPercent = flex.FlattenFloat64(float64(*from.DdnsTtlPercent))
 	m.DdnsUpdateOnRenew = types.BoolPointerValue(from.DdnsUpdateOnRenew)
 	m.DdnsUseConflictResolution = types.BoolPointerValue(from.DdnsUseConflictResolution)
-	m.DhcpConfig = FlattenIpamsvcDHCPConfig(ctx, from.DhcpConfig, diags)
+	m.DhcpConfig = FlattenIpamsvcDHCPConfigForSubnetOrAddressBlock(ctx, from.DhcpConfig, diags)
 	m.DhcpHost = flex.FlattenStringPointerWithNilAsEmpty(from.DhcpHost)
 	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DhcpUtilization = FlattenIpamsvcDHCPUtilization(ctx, from.DhcpUtilization, diags)


### PR DESCRIPTION
Some fields in dhcp_config is not allowed in subnet and address block. 
Since the model is the same, the API throws an error "field cannot be set". 
Marked the following fields as read only for address block and subnet. 
- echo_client_id
- abandoned_reclaim_time
- abandoned_reclaim_time_v6