### PR TITLE
fix: next available subnet/AB returns same block when count is used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
-	github.com/infobloxopen/bloxone-go-client v0.0.0-20240426160014-afd451b8d00d
+	github.com/infobloxopen/bloxone-go-client v0.0.0-20240426181640-3fcc0507692b
 	golang.org/x/exp v0.0.0-20240314144324-c7f7c6466f7f
 )
 

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/infobloxopen/bloxone-go-client v0.0.0-20240426160014-afd451b8d00d h1:p/R6oZNWjNAM2Iy7dXJA0+2c8zkSrw1by4n5a8GsZzA=
-github.com/infobloxopen/bloxone-go-client v0.0.0-20240426160014-afd451b8d00d/go.mod h1:vLxTz6q3NB16FVjsDAyhx3kuQycdmUtbvD5dYUVPjkI=
+github.com/infobloxopen/bloxone-go-client v0.0.0-20240426181640-3fcc0507692b h1:J502lcFbLbPinZQS0TN4anXcJQCJ+XAQbaMO7ceJgho=
+github.com/infobloxopen/bloxone-go-client v0.0.0-20240426181640-3fcc0507692b/go.mod h1:vLxTz6q3NB16FVjsDAyhx3kuQycdmUtbvD5dYUVPjkI=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/internal/service/ipam/api_address_resource.go
+++ b/internal/service/ipam/api_address_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	bloxoneclient "github.com/infobloxopen/bloxone-go-client/client"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -64,6 +65,13 @@ func (r *AddressResource) Create(ctx context.Context, req resource.CreateRequest
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !data.NextAvailableId.IsUnknown() && !data.NextAvailableId.IsNull() {
+		// Lock the mutex to serialize operations with the same key
+		// This is necessary to prevent the same block being returned.
+		utils.GlobalMutexStore.Lock(data.NextAvailableId.ValueString())
+		defer utils.GlobalMutexStore.Unlock(data.NextAvailableId.ValueString())
 	}
 
 	apiRes, _, err := r.client.IPAddressManagementAPI.

--- a/internal/service/ipam/api_address_resource_test.go
+++ b/internal/service/ipam/api_address_resource_test.go
@@ -287,6 +287,28 @@ func TestAccAddressResource_Tags(t *testing.T) {
 	})
 }
 
+func TestAccAddressResource_NextAvailableId_Count(t *testing.T) {
+	var resourceName = "bloxone_ipam_address.test_next_available_id_count"
+	spaceName := acctest.RandomNameWithPrefix("ip-space")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAddressNextAvailableIdCount(spaceName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName+".0", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".1", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".2", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".3", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".4", "parent", "bloxone_ipam_subnet.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAddressResource_NextAvailable_Subnet(t *testing.T) {
 	var resourceName = "bloxone_ipam_address.test_next_available"
 	var v1 ipam.Address
@@ -643,5 +665,16 @@ resource "bloxone_ipam_address" "test_next_available" {
     space = bloxone_ipam_ip_space.test.id
 }
 `, start, end)
+	return strings.Join([]string{testAccBaseWithIPSpaceAndSubnet(spaceName), config}, "")
+}
+
+func testAccAddressNextAvailableIdCount(spaceName string, count int) string {
+	config := fmt.Sprintf(`
+resource "bloxone_ipam_address" "test_next_available_id_count" {
+	next_available_id = bloxone_ipam_subnet.test.id
+	space = bloxone_ipam_ip_space.test.id
+	count = %d
+}   
+`, count)
 	return strings.Join([]string{testAccBaseWithIPSpaceAndSubnet(spaceName), config}, "")
 }

--- a/internal/service/ipam/api_fixed_address_resource.go
+++ b/internal/service/ipam/api_fixed_address_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	bloxoneclient "github.com/infobloxopen/bloxone-go-client/client"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -64,6 +65,13 @@ func (r *FixedAddressResource) Create(ctx context.Context, req resource.CreateRe
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !data.NextAvailableId.IsUnknown() && !data.NextAvailableId.IsNull() {
+		// Lock the mutex to serialize operations with the same key
+		// This is necessary to prevent the same block being returned.
+		utils.GlobalMutexStore.Lock(data.NextAvailableId.ValueString())
+		defer utils.GlobalMutexStore.Unlock(data.NextAvailableId.ValueString())
 	}
 
 	apiRes, _, err := r.client.IPAddressManagementAPI.

--- a/internal/service/ipam/api_fixed_address_resource_test.go
+++ b/internal/service/ipam/api_fixed_address_resource_test.go
@@ -530,6 +530,28 @@ func TestAccFixedAddressResource_Tags(t *testing.T) {
 	})
 }
 
+func TestAccFixedAddressResource_NextAvailableId_Count(t *testing.T) {
+	var resourceName = "bloxone_dhcp_fixed_address.test_next_available_id_count"
+	spaceName := acctest.RandomNameWithPrefix("ip-space")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFixedAddressNextAvailableIdCount(spaceName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName+".0", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".1", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".2", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".3", "parent", "bloxone_ipam_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".4", "parent", "bloxone_ipam_subnet.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFixedAddressExists(ctx context.Context, resourceName string, v *ipam.FixedAddress) resource.TestCheckFunc {
 	// Verify the resource exists in the cloud
 	return func(state *terraform.State) error {
@@ -842,5 +864,18 @@ resource "bloxone_dhcp_fixed_address" "test_inheritance_sources" {
 
 }
 `, address, matchType, matchValue, action)
+	return strings.Join([]string{testAccBaseWithIPSpaceAndSubnet(spaceName), config}, "")
+}
+
+func testAccFixedAddressNextAvailableIdCount(spaceName string, count int) string {
+	config := fmt.Sprintf(`
+resource "bloxone_dhcp_fixed_address" "test_next_available_id_count" {
+	next_available_id = bloxone_ipam_subnet.test.id
+	ip_space = bloxone_ipam_ip_space.test.id
+	count = %d
+	match_type = "mac"
+	match_value = "aa:aa:aa:aa:aa:${count.index + 10}"
+}   
+`, count)
 	return strings.Join([]string{testAccBaseWithIPSpaceAndSubnet(spaceName), config}, "")
 }

--- a/internal/service/ipam/api_ipam_host_resource.go
+++ b/internal/service/ipam/api_ipam_host_resource.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	bloxoneclient "github.com/infobloxopen/bloxone-go-client/client"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -62,6 +64,16 @@ func (r *IpamHostResource) Create(ctx context.Context, req resource.CreateReques
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
+	if !data.Addresses.IsNull() && !data.Addresses.IsUnknown() {
+		nextAvaialableIds := r.getNextAvailableIds(ctx, data)
+		for _, id := range nextAvaialableIds {
+			// Lock the mutex to serialize operations with the same key
+			// This is necessary to prevent the same block being returned.
+			utils.GlobalMutexStore.Lock(id)
+			defer utils.GlobalMutexStore.Unlock(id)
+		}
+	}
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -78,7 +90,6 @@ func (r *IpamHostResource) Create(ctx context.Context, req resource.CreateReques
 	res := apiRes.GetResult()
 	data.Flatten(ctx, &res, &resp.Diagnostics)
 
-	// Append next_available_id value to the addresses as it would be null when Response is flattened
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -165,4 +176,25 @@ func (r *IpamHostResource) Delete(ctx context.Context, req resource.DeleteReques
 
 func (r *IpamHostResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *IpamHostResource) getNextAvailableIds(ctx context.Context, data IpamsvcIpamHostModel) []string {
+	// Get the list of addresses to lock the mutex
+	nextAvailableIds := make(map[string]struct{})
+	var hostAdresses []IpamsvcHostAddressModel
+	data.Addresses.ElementsAs(ctx, &hostAdresses, false)
+	for _, a := range hostAdresses {
+		if !a.NextAvailableId.IsUnknown() && !a.NextAvailableId.IsNull() {
+			nextAvailableIds[a.NextAvailableId.ValueString()] = struct{}{}
+		}
+	}
+
+	// sort the list of ids to lock the mutex and return a list of unique ids
+	// the sort is necessary to prevent deadlocks
+	ids := make([]string, 0, len(nextAvailableIds))
+	for id := range nextAvailableIds {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
 }

--- a/internal/service/ipam/api_ipam_host_resource_test.go
+++ b/internal/service/ipam/api_ipam_host_resource_test.go
@@ -205,6 +205,28 @@ func TestAccIpamHostResource_Addresses(t *testing.T) {
 	})
 }
 
+func TestAccIpamHostResource_Addresses_NextAvailableId_Count(t *testing.T) {
+	var resourceName = "bloxone_ipam_host.test_next_available_id_count"
+	spaceName := acctest.RandomNameWithPrefix("ip-space")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIpamHostAddressesNextAvailableIdCount(spaceName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName+".0", "addresses.0.space", "bloxone_ipam_ip_space.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".1", "addresses.0.space", "bloxone_ipam_ip_space.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".2", "addresses.0.space", "bloxone_ipam_ip_space.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".3", "addresses.0.space", "bloxone_ipam_ip_space.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName+".4", "addresses.0.space", "bloxone_ipam_ip_space.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIpamHostExists(ctx context.Context, resourceName string, v *ipam.IpamHost) resource.TestCheckFunc {
 	// Verify the resource exists in the cloud
 	return func(state *terraform.State) error {
@@ -370,4 +392,19 @@ func testAccMultipleIPSpaceAndSubnet(spaceName1, spaceName2, spaceName3 string) 
 		space = bloxone_ipam_ip_space.test2.id
 	}
 `, spaceName1, spaceName2, spaceName3)
+}
+
+func testAccIpamHostAddressesNextAvailableIdCount(spaceName string, count int) string {
+	config := fmt.Sprintf(`
+resource "bloxone_ipam_host" "test_next_available_id_count" {
+	count = %d
+    name = "host-${count.index}"
+	addresses = [
+		{
+			next_available_id = bloxone_ipam_subnet.test.id
+		}
+	]
+}
+`, count)
+	return strings.Join([]string{testAccBaseWithIPSpaceAndSubnet(spaceName), config}, "")
 }

--- a/internal/service/ipam/api_subnet_resource.go
+++ b/internal/service/ipam/api_subnet_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	bloxoneclient "github.com/infobloxopen/bloxone-go-client/client"
+	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -64,6 +65,13 @@ func (r *SubnetResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !data.NextAvailableId.IsUnknown() && !data.NextAvailableId.IsNull() {
+		// Lock the mutex to serialize operations with the same key
+		// This is necessary to prevent the same block being returned.
+		utils.GlobalMutexStore.Lock(data.NextAvailableId.ValueString())
+		defer utils.GlobalMutexStore.Unlock(data.NextAvailableId.ValueString())
 	}
 
 	apiRes, _, err := r.client.IPAddressManagementAPI.

--- a/internal/utils/mutex_store.go
+++ b/internal/utils/mutex_store.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"sync"
+)
+
+// GlobalMutexStore is a global mutex store.
+var GlobalMutexStore = newMutexStore()
+
+// mutexStore is a store for mutexes.
+type mutexStore struct {
+	mu      sync.Mutex
+	mutexes map[string]*sync.Mutex
+}
+
+// newMutexStore creates a new mutexStore.
+// It is used to store mutexes to serialize operations with the same key.
+// E.g. for next available IP address calculation.
+func newMutexStore() *mutexStore {
+	return &mutexStore{
+		mutexes: make(map[string]*sync.Mutex),
+	}
+}
+
+// get returns a mutex for the given key.
+func (s *mutexStore) get(key string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.mutexes[key]; !ok {
+		s.mutexes[key] = &sync.Mutex{}
+	}
+
+	return s.mutexes[key]
+}
+
+// Lock locks the mutex for the given key.
+func (s *mutexStore) Lock(key string) {
+	s.get(key).Lock()
+}
+
+// Unlock unlocks the mutex for the given key.
+func (s *mutexStore) Unlock(key string) {
+	s.get(key).Unlock()
+}

--- a/vendor/github.com/infobloxopen/bloxone-go-client/option/option.go
+++ b/vendor/github.com/infobloxopen/bloxone-go-client/option/option.go
@@ -14,7 +14,9 @@ type ClientOption func(configuration *internal.Configuration)
 // Optional. Default is https://csp.infoblox.com
 func WithCSPUrl(cspURL string) ClientOption {
 	return func(configuration *internal.Configuration) {
-		configuration.CSPURL = cspURL
+		if cspURL != "" {
+			configuration.CSPURL = cspURL
+		}
 	}
 }
 
@@ -27,7 +29,9 @@ func WithCSPUrl(cspURL string) ClientOption {
 // Required.
 func WithAPIKey(apiKey string) ClientOption {
 	return func(configuration *internal.Configuration) {
-		configuration.APIKey = apiKey
+		if apiKey != "" {
+			configuration.APIKey = apiKey
+		}
 	}
 }
 
@@ -35,7 +39,9 @@ func WithAPIKey(apiKey string) ClientOption {
 // Optional. The default HTTPClient will be used if not provided.
 func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(configuration *internal.Configuration) {
-		configuration.HTTPClient = httpClient
+		if httpClient != nil {
+			configuration.HTTPClient = httpClient
+		}
 	}
 }
 
@@ -52,7 +58,9 @@ func WithDefaultTags(defaultTags map[string]string) ClientOption {
 // Optional. If not provided, the client name will be set to "bloxone-go-client".
 func WithClientName(clientName string) ClientOption {
 	return func(configuration *internal.Configuration) {
-		configuration.ClientName = clientName
+		if clientName != "" {
+			configuration.ClientName = clientName
+		}
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -280,7 +280,7 @@ github.com/huandu/xstrings
 # github.com/imdario/mergo v0.3.15
 ## explicit; go 1.13
 github.com/imdario/mergo
-# github.com/infobloxopen/bloxone-go-client v0.0.0-20240426160014-afd451b8d00d
+# github.com/infobloxopen/bloxone-go-client v0.0.0-20240426181640-3fcc0507692b
 ## explicit; go 1.19
 github.com/infobloxopen/bloxone-go-client/anycast
 github.com/infobloxopen/bloxone-go-client/client


### PR DESCRIPTION
When using the Terraform count meta argument to create multiple subnets or address blocks in bloxone_ipam_subnet and bloxone_ipam_address_block resources with next available, the same IP range is returned multiple times, causing an error. 

Bloxone API calls that support "next available" returns an error if the address it determined as next available was already allocated in a concurrent call. 

This PR introduces mutex to serialize calls that are made for getting next available ranges