### PR TITLE
fix: internal_domains list ordering changes after apply

### DIFF
--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 )
 
@@ -85,7 +87,10 @@ func FlattenFrameworkMapString(ctx context.Context, m map[string]interface{}, di
 	return tfMap
 }
 
-func ExpandFrameworkListString(ctx context.Context, tfList types.List, diags *diag.Diagnostics) []string {
+func ExpandFrameworkListString(ctx context.Context, tfList interface {
+	basetypes.ListValuable
+	ElementsAs(ctx context.Context, target interface{}, allowUnhandled bool) diag.Diagnostics
+}, diags *diag.Diagnostics) []string {
 	if tfList.IsNull() || tfList.IsUnknown() {
 		return nil
 	}
@@ -117,6 +122,15 @@ func FlattenFrameworkListString(ctx context.Context, l []string, diags *diag.Dia
 		return types.ListNull(types.StringType)
 	}
 	tfList, d := types.ListValueFrom(ctx, types.StringType, l)
+	diags.Append(d...)
+	return tfList
+}
+
+func FlattenFrameworkCustomListString(ctx context.Context, l []string, diags *diag.Diagnostics) internaltypes.UnorderedListValue[types.String] {
+	if len(l) == 0 {
+		return internaltypes.NewUnorderedListValueNull[types.String](ctx)
+	}
+	tfList, d := internaltypes.NewUnorderedListValueFrom[types.String](ctx, l)
 	diags.Append(d...)
 	return tfList
 }

--- a/internal/service/dfp/api_dfp_data_source_test.go
+++ b/internal/service/dfp/api_dfp_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDfpDataSource_Filters(t *testing.T) {
 	var v dfp.Dfp
 	hostName := acctest.RandomNameWithPrefix("host")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -37,7 +37,6 @@ func TestAccDfpDataSource_Filters(t *testing.T) {
 
 func testAccCheckDfpResourceAttrPair(resourceName, dataSourceName string) []resource.TestCheckFunc {
 	return []resource.TestCheckFunc{
-		resource.TestCheckResourceAttrPair(resourceName, "created_time", dataSourceName, "results.0.created_time"),
 		resource.TestCheckResourceAttrPair(resourceName, "forwarding_policy", dataSourceName, "results.0.forwarding_policy"),
 		resource.TestCheckResourceAttrPair(resourceName, "host", dataSourceName, "results.0.host"),
 		resource.TestCheckResourceAttrPair(resourceName, "net_addr_policy_ids", dataSourceName, "results.0.net_addr_policy_ids"),
@@ -58,7 +57,8 @@ func testAccCheckDfpResourceAttrPair(resourceName, dataSourceName string) []reso
 func testAccDfpDataSourceConfigFilters(hostName string) string {
 	config := `
 resource "bloxone_dfp_service" "test" {
-  service_id = bloxone_infra_service.example.id
+	service_id = bloxone_infra_service.example.id
+	internal_domain_lists = [one(data.bloxone_td_internal_domain_lists.default.results).id]
 }
 data "bloxone_dfp_services" "test" {
 	filters = {
@@ -66,5 +66,5 @@ data "bloxone_dfp_services" "test" {
 	}
 }
 `
-	return strings.Join([]string{testAccBaseWithInfraService(hostName), config}, "")
+	return strings.Join([]string{testAccBaseDfp(hostName), config}, "")
 }

--- a/internal/service/dfp/api_dfp_resource_test.go
+++ b/internal/service/dfp/api_dfp_resource_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/utils"
 
 	"github.com/infobloxopen/bloxone-go-client/dfp"
@@ -23,7 +24,7 @@ func TestAccDfpResource_basic(t *testing.T) {
 	var v dfp.Dfp
 	hostName := acctest.RandomNameWithPrefix("host")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -53,7 +54,7 @@ func TestAccDfpResource_InternalDomainLists(t *testing.T) {
 	var v dfp.Dfp
 	hostName := acctest.RandomNameWithPrefix("host")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -62,7 +63,8 @@ func TestAccDfpResource_InternalDomainLists(t *testing.T) {
 				Config: testAccDfpInternalDomainLists(hostName, "test1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDfpExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.0", "bloxone_td_internal_domain_list.test1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.0", "data.bloxone_td_internal_domain_lists.default", "results.0.id"),
+					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.1", "bloxone_td_internal_domain_list.test1", "id"),
 				),
 			},
 			// Update and Read
@@ -70,7 +72,8 @@ func TestAccDfpResource_InternalDomainLists(t *testing.T) {
 				Config: testAccDfpInternalDomainLists(hostName, "test2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDfpExists(context.Background(), resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.0", "bloxone_td_internal_domain_list.test2", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.0", "data.bloxone_td_internal_domain_lists.default", "results.0.id"),
+					resource.TestCheckResourceAttrPair(resourceName, "internal_domain_lists.1", "bloxone_td_internal_domain_list.test2", "id"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -83,7 +86,7 @@ func TestAccDfpResource_ResolversAll(t *testing.T) {
 	var v dfp.Dfp
 	hostName := acctest.RandomNameWithPrefix("host")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -114,6 +117,38 @@ func TestAccDfpResource_ResolversAll(t *testing.T) {
 	})
 }
 
+func TestAccDfpResource_ResolversAll_Protocols_Multiple(t *testing.T) {
+	resourceName := "bloxone_dfp_service.test_resolvers_all_protocols_multiple"
+	var v dfp.Dfp
+	hostName := acctest.RandomNameWithPrefix("host")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: testAccDfpResolverAllProtocolMultiple(hostName, []string{"DO53", "DOT"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDfpExists(context.Background(), resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "resolvers_all.0.protocols.0", "DO53"),
+					resource.TestCheckResourceAttr(resourceName, "resolvers_all.0.protocols.1", "DOT"),
+				),
+			},
+			// Update and Read
+			{
+				Config: testAccDfpResolverAllProtocolMultiple(hostName, []string{"DOT", "DO53"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDfpExists(context.Background(), resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "resolvers_all.0.protocols.0", "DOT"),
+					resource.TestCheckResourceAttr(resourceName, "resolvers_all.0.protocols.1", "DO53"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func testAccCheckDfpExists(ctx context.Context, resourceName string, v *dfp.Dfp) resource.TestCheckFunc {
 	// Verify the resource exists in the cloud
 	return func(state *terraform.State) error {
@@ -136,30 +171,31 @@ func testAccCheckDfpExists(ctx context.Context, resourceName string, v *dfp.Dfp)
 	}
 }
 
-func testAccBaseWithInfraService(hostName string) string {
+func testAccBaseWithInfraService(hostName, serviceType string) string {
 	return fmt.Sprintf(`
 resource "bloxone_infra_host" "test_host" {
-	display_name = %q
+	display_name = %[1]q
 }
 
 resource "bloxone_infra_service" "example" {
-	name = "example_dfp_service"
+	name = "%[1]s-%[2]s"
 	pool_id = bloxone_infra_host.test_host.pool_id
-	service_type = "dfp"
+	service_type = "%[2]s"
 	desired_state = "start"
 	wait_for_state = false
 	depends_on = [bloxone_infra_host.test_host]
 }
-`, hostName)
+`, hostName, serviceType)
 }
 
 func testAccDfpBasicConfig(hostName string) string {
 	config := `
 resource "bloxone_dfp_service" "test" {
 	service_id = bloxone_infra_service.example.id
+	internal_domain_lists=[one(data.bloxone_td_internal_domain_lists.default.results).id]
 }
 `
-	return strings.Join([]string{testAccBaseWithInfraService(hostName), config}, "")
+	return strings.Join([]string{testAccBaseDfp(hostName), config}, "")
 }
 
 func testAccDfpInternalDomainLists(hostName, internalDomainList string) string {
@@ -177,16 +213,17 @@ resource "bloxone_td_internal_domain_list" "test2" {
 }
 resource "bloxone_dfp_service" "test_internal_domain_lists" {
 	service_id = bloxone_infra_service.example.id
-	internal_domain_lists = [ bloxone_td_internal_domain_list.%s.id ]
+	internal_domain_lists = [one(data.bloxone_td_internal_domain_lists.default.results).id, bloxone_td_internal_domain_list.%s.id ]
 }
 `, list1, list2, internalDomainList)
-	return strings.Join([]string{testAccBaseWithInfraService(hostName), config}, "")
+	return strings.Join([]string{testAccBaseDfp(hostName), config}, "")
 }
 
 func testAccDfpResolverAll(hostName, resolverAddress, isFallback, isLocal, protocols string) string {
 	config := fmt.Sprintf(`
 resource "bloxone_dfp_service" "test_resolvers_all" {
-  service_id = bloxone_infra_service.example.id
+	service_id = bloxone_infra_service.example.id
+	internal_domain_lists = [one(data.bloxone_td_internal_domain_lists.default.results).id]
 	resolvers_all = [
 		{
 			address = %q
@@ -197,5 +234,42 @@ resource "bloxone_dfp_service" "test_resolvers_all" {
 	]
 }
 `, resolverAddress, isFallback, isLocal, protocols)
-	return strings.Join([]string{testAccBaseWithInfraService(hostName), config}, "")
+	return strings.Join([]string{testAccBaseDfp(hostName), config}, "")
+}
+
+func testAccDfpResolverAllProtocolMultiple(hostName string, protocols []string) string {
+	protocolsStr := ""
+	for i, protocol := range protocols {
+		if i > 0 {
+			protocolsStr += ","
+		}
+		protocolsStr += fmt.Sprintf(`%q`, protocol)
+	}
+
+	config := fmt.Sprintf(`
+resource "bloxone_dfp_service" "test_resolvers_all_protocols_multiple" {
+	service_id = bloxone_infra_service.example.id
+	internal_domain_lists = [one(data.bloxone_td_internal_domain_lists.default.results).id]
+	resolvers_all = [
+		{
+			address = "2.2.2.2"
+			is_fallback = "false"
+			is_local = "true"
+			protocols = [%s]
+		}
+	]
+}
+`, protocolsStr)
+	return strings.Join([]string{testAccBaseDfp(hostName), config}, "")
+}
+
+func testAccBaseDfp(hostName string) string {
+	// This is a workaround, ideally it would be nice to have the default internal domain list in the provider
+	config := fmt.Sprintf(`
+data "bloxone_td_internal_domain_lists" "default" {
+	filters = {
+		is_default = true
+	}
+}`)
+	return strings.Join([]string{testAccBaseWithInfraService(hostName, "dfp"), config}, "")
 }

--- a/internal/service/dfp/api_dfp_resource_test.go
+++ b/internal/service/dfp/api_dfp_resource_test.go
@@ -265,11 +265,11 @@ resource "bloxone_dfp_service" "test_resolvers_all_protocols_multiple" {
 
 func testAccBaseDfp(hostName string) string {
 	// This is a workaround, ideally it would be nice to have the default internal domain list in the provider
-	config := fmt.Sprintf(`
+	config := `
 data "bloxone_td_internal_domain_lists" "default" {
 	filters = {
 		is_default = true
 	}
-}`)
+}`
 	return strings.Join([]string{testAccBaseWithInfraService(hostName, "dfp"), config}, "")
 }

--- a/internal/service/dfp/model_resolver.go
+++ b/internal/service/dfp/model_resolver.go
@@ -10,22 +10,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/dfp"
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
 )
 
 type ResolverModel struct {
-	Address    types.String `tfsdk:"address"`
-	IsFallback types.Bool   `tfsdk:"is_fallback"`
-	IsLocal    types.Bool   `tfsdk:"is_local"`
-	Protocols  types.List   `tfsdk:"protocols"`
+	Address    types.String                                   `tfsdk:"address"`
+	IsFallback types.Bool                                     `tfsdk:"is_fallback"`
+	IsLocal    types.Bool                                     `tfsdk:"is_local"`
+	Protocols  internaltypes.UnorderedListValue[types.String] `tfsdk:"protocols"`
 }
 
 var ResolverAttrTypes = map[string]attr.Type{
 	"address":     types.StringType,
 	"is_fallback": types.BoolType,
 	"is_local":    types.BoolType,
-	"protocols":   types.ListType{ElemType: types.StringType},
+	"protocols":   internaltypes.UnorderedListOfStringType,
 }
 
 var ResolverResourceSchemaAttributes = map[string]schema.Attribute{
@@ -42,6 +43,7 @@ var ResolverResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "Mark it true to set internal or local DNS servers' IPv4 or IPv6 addresses that are used as DNS resolvers",
 	},
 	"protocols": schema.ListAttribute{
+		CustomType:          internaltypes.UnorderedListOfStringType,
 		ElementType:         types.StringType,
 		Optional:            true,
 		MarkdownDescription: "The list of DNS resolver communication protocols.",
@@ -73,7 +75,7 @@ func (m *ResolverModel) Expand(ctx context.Context, diags *diag.Diagnostics) *df
 	return to
 }
 
-func ExpandDNSProtocol(ctx context.Context, tfList types.List, diags *diag.Diagnostics) []dfp.DNSProtocol {
+func ExpandDNSProtocol(ctx context.Context, tfList internaltypes.UnorderedListValue[types.String], diags *diag.Diagnostics) []dfp.DNSProtocol {
 	if tfList.IsNull() || tfList.IsUnknown() {
 		return nil
 	}
@@ -106,11 +108,11 @@ func (m *ResolverModel) Flatten(ctx context.Context, from *dfp.Resolver, diags *
 	m.Protocols = FlattenDNSProtocol(ctx, from.Protocols, diags)
 }
 
-func FlattenDNSProtocol(ctx context.Context, l []dfp.DNSProtocol, diags *diag.Diagnostics) types.List {
+func FlattenDNSProtocol(ctx context.Context, l []dfp.DNSProtocol, diags *diag.Diagnostics) internaltypes.UnorderedListValue[types.String] {
 	if len(l) == 0 {
-		return types.ListNull(types.StringType)
+		return internaltypes.NewUnorderedListValueNull[types.String](ctx)
 	}
-	tfList, d := types.ListValueFrom(ctx, types.StringType, l)
+	tfList, d := internaltypes.NewUnorderedListValueFrom[types.String](ctx, l)
 	diags.Append(d...)
 	return tfList
 }

--- a/internal/service/fw/api_internal_domain_list_data_source_test.go
+++ b/internal/service/fw/api_internal_domain_list_data_source_test.go
@@ -66,7 +66,6 @@ func testAccCheckInternalDomainListResourceAttrPair(resourceName, dataSourceName
 		resource.TestCheckResourceAttrPair(resourceName, "id", dataSourceName, "results.0.id"),
 		resource.TestCheckResourceAttrPair(resourceName, "name", dataSourceName, "results.0.name"),
 		resource.TestCheckResourceAttrPair(resourceName, "tags", dataSourceName, "results.0.tags"),
-		resource.TestCheckResourceAttrPair(resourceName, "updated_time", dataSourceName, "results.0.updated_time"),
 	}
 }
 

--- a/internal/service/fw/api_internal_domain_list_resource_test.go
+++ b/internal/service/fw/api_internal_domain_list_resource_test.go
@@ -123,6 +123,41 @@ func TestAccInternalDomainListResource_InternalDomains(t *testing.T) {
 	})
 }
 
+func TestAccInternalDomainListResource_InternalDomains_Multiple(t *testing.T) {
+	resourceName := "bloxone_td_internal_domain_list.test_internal_domain_multiple"
+	var v fw.InternalDomains
+	var name = acctest.RandomNameWithPrefix("td-internal_domain_list")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read
+			{
+				Config: testAccInternalDomainListInternalDomainMultiple(name, []string{"example.somedomain.com", "dev.somedomain.com", "internal.somedomain.com", "test.somedomain.com"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInternalDomainListExists(context.Background(), resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.0", "example.somedomain.com"),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.1", "dev.somedomain.com"),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.2", "internal.somedomain.com"),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.3", "test.somedomain.com"),
+				),
+			},
+			// Update and Read
+			{
+				Config: testAccInternalDomainListInternalDomainMultiple(name, []string{"test.newdomain.com", "internal.newdomain.com", "newdomain.com"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInternalDomainListExists(context.Background(), resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.0", "test.newdomain.com"),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.1", "internal.newdomain.com"),
+					resource.TestCheckResourceAttr(resourceName, "internal_domains.2", "newdomain.com"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccInternalDomainListResource_Name(t *testing.T) {
 	resourceName := "bloxone_td_internal_domain_list.test_name"
 	var v1, v2 fw.InternalDomains
@@ -277,6 +312,24 @@ resource "bloxone_td_internal_domain_list" "test_internal_domain" {
 	internal_domains = [%q]
 }
 `, name, internalDomains)
+}
+
+func testAccInternalDomainListInternalDomainMultiple(name string, internalDomains []string) string {
+	// join internalDomains into a string separated by commas, and quote each element
+	internalDomainsStr := ""
+	for i, domain := range internalDomains {
+		if i > 0 {
+			internalDomainsStr += ","
+		}
+		internalDomainsStr += fmt.Sprintf(`%q`, domain)
+	}
+
+	return fmt.Sprintf(`
+resource "bloxone_td_internal_domain_list" "test_internal_domain_multiple" {
+	name = %q
+	internal_domains = [%s]
+}
+`, name, internalDomainsStr)
 }
 
 func testAccInternalDomainName(name, internalDomains string) string {

--- a/internal/service/fw/model_atcfw_internal_domains.go
+++ b/internal/service/fw/model_atcfw_internal_domains.go
@@ -34,7 +34,7 @@ var AtcfwInternalDomainsAttrTypes = map[string]attr.Type{
 	"created_time":     timetypes.RFC3339Type{},
 	"description":      types.StringType,
 	"id":               types.Int64Type,
-	"internal_domains": internaltypes.UnorderedList[types.String]{},
+	"internal_domains": internaltypes.UnorderedListOfStringType,
 	"is_default":       types.BoolType,
 	"name":             types.StringType,
 	"tags":             types.MapType{ElemType: types.StringType},

--- a/internal/service/fw/model_atcfw_internal_domains.go
+++ b/internal/service/fw/model_atcfw_internal_domains.go
@@ -12,29 +12,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/fw"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 )
 
 type AtcfwInternalDomainsModel struct {
-	CreatedTime     timetypes.RFC3339 `tfsdk:"created_time"`
-	Description     types.String      `tfsdk:"description"`
-	Id              types.Int64       `tfsdk:"id"`
-	InternalDomains types.List        `tfsdk:"internal_domains"`
-	IsDefault       types.Bool        `tfsdk:"is_default"`
-	Name            types.String      `tfsdk:"name"`
-	Tags            types.Map         `tfsdk:"tags"`
-	UpdatedTime     timetypes.RFC3339 `tfsdk:"updated_time"`
+	CreatedTime     timetypes.RFC3339                              `tfsdk:"created_time"`
+	Description     types.String                                   `tfsdk:"description"`
+	Id              types.Int64                                    `tfsdk:"id"`
+	InternalDomains internaltypes.UnorderedListValue[types.String] `tfsdk:"internal_domains"`
+	IsDefault       types.Bool                                     `tfsdk:"is_default"`
+	Name            types.String                                   `tfsdk:"name"`
+	Tags            types.Map                                      `tfsdk:"tags"`
+	UpdatedTime     timetypes.RFC3339                              `tfsdk:"updated_time"`
 }
 
 var AtcfwInternalDomainsAttrTypes = map[string]attr.Type{
 	"created_time":     timetypes.RFC3339Type{},
 	"description":      types.StringType,
 	"id":               types.Int64Type,
-	"internal_domains": types.ListType{ElemType: types.StringType},
+	"internal_domains": internaltypes.UnorderedList[types.String]{},
 	"is_default":       types.BoolType,
 	"name":             types.StringType,
 	"tags":             types.MapType{ElemType: types.StringType},
@@ -61,6 +61,7 @@ var AtcfwInternalDomainsResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The Internal Domain object identifier.",
 	},
 	"internal_domains": schema.ListAttribute{
+		CustomType:          internaltypes.UnorderedListOfStringType,
 		ElementType:         types.StringType,
 		Optional:            true,
 		MarkdownDescription: "The list of internal domains, should be unique to each other and has to be read-only from the API level.",
@@ -86,18 +87,6 @@ var AtcfwInternalDomainsResourceSchemaAttributes = map[string]schema.Attribute{
 		Computed:            true,
 		MarkdownDescription: "The time when this Internal domain list object was last updated.",
 	},
-}
-
-func ExpandAtcfwInternalDomains(ctx context.Context, o types.Object, diags *diag.Diagnostics) *fw.InternalDomains {
-	if o.IsNull() || o.IsUnknown() {
-		return nil
-	}
-	var m AtcfwInternalDomainsModel
-	diags.Append(o.As(ctx, &m, basetypes.ObjectAsOptions{})...)
-	if diags.HasError() {
-		return nil
-	}
-	return m.Expand(ctx, diags)
 }
 
 func (m *AtcfwInternalDomainsModel) Expand(ctx context.Context, diags *diag.Diagnostics) *fw.InternalDomains {
@@ -135,7 +124,7 @@ func (m *AtcfwInternalDomainsModel) Flatten(ctx context.Context, from *fw.Intern
 	m.CreatedTime = timetypes.NewRFC3339TimePointerValue(from.CreatedTime)
 	m.Description = flex.FlattenStringPointer(from.Description)
 	m.Id = flex.FlattenInt32Pointer(from.Id)
-	m.InternalDomains = flex.FlattenFrameworkListString(ctx, from.InternalDomains, diags)
+	m.InternalDomains = flex.FlattenFrameworkCustomListString(ctx, from.InternalDomains, diags)
 	m.IsDefault = types.BoolPointerValue(from.IsDefault)
 	m.Name = flex.FlattenStringPointer(from.Name)
 	m.Tags = flex.FlattenFrameworkMapString(ctx, from.Tags, diags)

--- a/internal/types/unordered_list.go
+++ b/internal/types/unordered_list.go
@@ -1,0 +1,183 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"golang.org/x/exp/slices"
+)
+
+var UnorderedListOfStringType = UnorderedList[basetypes.StringValue]{basetypes.ListType{ElemType: basetypes.StringType{}}}
+
+var _ basetypes.ListValuableWithSemanticEquals = UnorderedListValue[basetypes.StringValue]{}
+var _ basetypes.ListTypable = UnorderedList[basetypes.StringValue]{}
+
+// UnorderedList is a type representing a list of values where the order of the elements is not significant.
+type UnorderedList[T attr.Value] struct {
+	basetypes.ListType
+}
+
+func NewUnorderedList[T attr.Value](ctx context.Context) UnorderedList[T] {
+	return UnorderedList[T]{basetypes.ListType{ElemType: newAttrTypeOf[T](ctx)}}
+}
+
+func (t UnorderedList[T]) Equal(o attr.Type) bool {
+	other, ok := o.(UnorderedList[T])
+
+	if !ok {
+		return false
+	}
+
+	return t.ListType.Equal(other.ListType)
+}
+
+func (UnorderedList[T]) String() string {
+	return fmt.Sprintf("UnorderedList[%T]", new(T))
+}
+
+func (t UnorderedList[T]) ValueFromList(ctx context.Context, in basetypes.ListValue) (basetypes.ListValuable, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if in.IsNull() {
+		return NewUnorderedListValueNull[T](ctx), diags
+	}
+
+	if in.IsUnknown() {
+		return NewUnorderedListValueUnknown[T](ctx), diags
+	}
+
+	v, d := basetypes.NewListValue(newAttrTypeOf[T](ctx), in.Elements())
+	diags.Append(d...)
+	if diags.HasError() {
+		return NewUnorderedListValueUnknown[T](ctx), diags
+	}
+
+	return UnorderedListValue[T]{ListValue: v}, diags
+}
+
+func (t UnorderedList[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.ListType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	listValue, ok := attrValue.(basetypes.ListValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	listValuable, diags := t.ValueFromList(ctx, listValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting ListValue to ListValuable: %v", diags)
+	}
+
+	return listValuable, nil
+}
+
+func (UnorderedList[T]) ValueType(context.Context) attr.Value {
+	return UnorderedListValue[T]{}
+}
+
+type UnorderedListValue[T attr.Value] struct {
+	basetypes.ListValue
+}
+
+func (v UnorderedListValue[T]) ListSemanticEquals(ctx context.Context, newValuable basetypes.ListValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(UnorderedListValue[T])
+	if !ok {
+		return false, diags
+	}
+
+	o, d := v.ToListValue(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	n, d := newValue.ToListValue(ctx)
+	diags.Append(d...)
+	if diags.HasError() {
+		return false, diags
+	}
+
+	oldElems, newElems := o.Elements(), n.Elements()
+
+	if len(oldElems) != len(newElems) {
+		return false, diags
+	}
+
+	for _, newElem := range newElems {
+		found := false
+		for i, oldElem := range oldElems {
+			if oldElem.Equal(newElem) {
+				oldElems = slices.Delete(oldElems, i, i+1)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, diags
+		}
+	}
+
+	return len(oldElems) == 0, diags
+}
+
+func (v UnorderedListValue[T]) Equal(o attr.Value) bool {
+	other, ok := o.(UnorderedListValue[T])
+
+	if !ok {
+		return false
+	}
+
+	return v.ListValue.Equal(other.ListValue)
+}
+
+func (UnorderedListValue[T]) Type(ctx context.Context) attr.Type {
+	return NewUnorderedList[T](ctx)
+}
+
+func NewUnorderedListValueNull[T attr.Value](ctx context.Context) UnorderedListValue[T] {
+	return UnorderedListValue[T]{ListValue: basetypes.NewListNull(newAttrTypeOf[T](ctx))}
+}
+
+func NewUnorderedListValueUnknown[T attr.Value](ctx context.Context) UnorderedListValue[T] {
+	return UnorderedListValue[T]{ListValue: basetypes.NewListUnknown(newAttrTypeOf[T](ctx))}
+}
+
+func NewUnorderedListValue[T attr.Value](ctx context.Context, elements []attr.Value) (UnorderedListValue[T], diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	v, d := basetypes.NewListValue(newAttrTypeOf[T](ctx), elements)
+	diags.Append(d...)
+	if diags.HasError() {
+		return NewUnorderedListValueUnknown[T](ctx), diags
+	}
+
+	return UnorderedListValue[T]{ListValue: v}, diags
+}
+
+func NewUnorderedListValueFrom[T attr.Value](ctx context.Context, elements any) (UnorderedListValue[T], diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	v, d := basetypes.NewListValueFrom(ctx, newAttrTypeOf[T](ctx), elements)
+	diags.Append(d...)
+	if diags.HasError() {
+		return NewUnorderedListValueUnknown[T](ctx), diags
+	}
+
+	return UnorderedListValue[T]{ListValue: v}, diags
+}
+
+func newAttrTypeOf[T attr.Value](ctx context.Context) attr.Type {
+	return (*new(T)).Type(ctx)
+}


### PR DESCRIPTION
- Fixes the issue where the plan is not empty after apply for `bloxone_td_internal_domain_list`
- Created a custom list type `UnorderedList` with support for semantic equality that disregards the order. 