### PR TITLE
fix tfproviderlint action

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -53,7 +53,12 @@ jobs:
     name: Terraform Provider Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.1
-    - uses: bflad/tfproviderlint-github-action@master
-      with:
-        args: ./...
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-go@v4.1.0
+        with:
+          go-version: '1.22'
+          cache: false
+      - name: install
+        run: go install github.com/bflad/tfproviderlint/cmd/tfproviderlintx@v0.30.0
+      - name: tfproviderlintx
+        run: tfproviderlintx ./...


### PR DESCRIPTION
The action is failing on some recent PRs with the error ```tfproviderlint: err: exit status 1: stderr: go: go.mod requires go >= 1.22 (running go 1.21.10; GOTOOLCHAIN=local)```

Changed from using the published action to installing via go and then running it on v1.22