### PR TITLE
Fix: delegation_servers.address giving non-empty plan when not provided

### DIFF
--- a/internal/service/dns_config/model_config_delegation_server.go
+++ b/internal/service/dns_config/model_config_delegation_server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	schema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
@@ -29,6 +30,8 @@ var ConfigDelegationServerAttrTypes = map[string]attr.Type{
 var ConfigDelegationServerResourceSchemaAttributes = map[string]schema.Attribute{
 	"address": schema.StringAttribute{
 		Optional:            true,
+		Computed:            true,
+		Default:             stringdefault.StaticString(""),
 		MarkdownDescription: "Optional. IP Address of nameserver.  Only required when fqdn of a delegation server falls under delegation fqdn",
 	},
 	"fqdn": schema.StringAttribute{


### PR DESCRIPTION
`delegation_servers.address` is only required when the fqdn of the delegation server falls under the delegation. It is optional otherwise. However when unset, the API returns an empty string `""` instead of `null`. Added default as `""` in the terraform model so that null is always treated as an empty string for this field