### PR TITLE
Fix: Correct List Ordering for Subnets and Address Blocks in IPAM Federation

### DIFF
--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -141,6 +141,12 @@ func FlattenFrameworkUnorderedList[T any](ctx context.Context, elemType attr.Typ
 	return tfList
 }
 
+func FlattenFrameworkUnorderedListNotNull[T any](ctx context.Context, elemType attr.Type, data []T, diags *diag.Diagnostics) internaltypes.UnorderedListValue {
+	tfList, d := internaltypes.NewUnorderedListValueFrom(ctx, elemType, data)
+	diags.Append(d...)
+	return tfList
+}
+
 func FlattenFrameworkListInt32(ctx context.Context, l []int32, diags *diag.Diagnostics) types.List {
 	if len(l) == 0 {
 		return types.ListNull(types.Int64Type)

--- a/internal/service/ipam/model_ipamsvc_address_block.go
+++ b/internal/service/ipam/model_ipamsvc_address_block.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"context"
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -27,51 +28,51 @@ import (
 )
 
 type IpamsvcAddressBlockModel struct {
-	Address                    types.String      `tfsdk:"address"`
-	AsmConfig                  types.Object      `tfsdk:"asm_config"`
-	AsmScopeFlag               types.Int64       `tfsdk:"asm_scope_flag"`
-	Cidr                       types.Int64       `tfsdk:"cidr"`
-	Comment                    types.String      `tfsdk:"comment"`
-	CompartmentId              types.String      `tfsdk:"compartment_id"`
-	CreatedAt                  timetypes.RFC3339 `tfsdk:"created_at"`
-	DdnsClientUpdate           types.String      `tfsdk:"ddns_client_update"`
-	DdnsConflictResolutionMode types.String      `tfsdk:"ddns_conflict_resolution_mode"`
-	DdnsDomain                 types.String      `tfsdk:"ddns_domain"`
-	DdnsGenerateName           types.Bool        `tfsdk:"ddns_generate_name"`
-	DdnsGeneratedPrefix        types.String      `tfsdk:"ddns_generated_prefix"`
-	DdnsSendUpdates            types.Bool        `tfsdk:"ddns_send_updates"`
-	DdnsTtlPercent             types.Float64     `tfsdk:"ddns_ttl_percent"`
-	DdnsUpdateOnRenew          types.Bool        `tfsdk:"ddns_update_on_renew"`
-	DdnsUseConflictResolution  types.Bool        `tfsdk:"ddns_use_conflict_resolution"`
-	Delegation                 types.String      `tfsdk:"delegation"`
-	DhcpConfig                 types.Object      `tfsdk:"dhcp_config"`
-	DhcpOptions                types.List        `tfsdk:"dhcp_options"`
-	DhcpUtilization            types.Object      `tfsdk:"dhcp_utilization"`
-	DiscoveryAttrs             types.Map         `tfsdk:"discovery_attrs"`
-	DiscoveryMetadata          types.Map         `tfsdk:"discovery_metadata"`
-	ExternalKeys               types.Map         `tfsdk:"external_keys"`
-	FederatedRealms            types.List        `tfsdk:"federated_realms"`
-	HeaderOptionFilename       types.String      `tfsdk:"header_option_filename"`
-	HeaderOptionServerAddress  types.String      `tfsdk:"header_option_server_address"`
-	HeaderOptionServerName     types.String      `tfsdk:"header_option_server_name"`
-	HostnameRewriteChar        types.String      `tfsdk:"hostname_rewrite_char"`
-	HostnameRewriteEnabled     types.Bool        `tfsdk:"hostname_rewrite_enabled"`
-	HostnameRewriteRegex       types.String      `tfsdk:"hostname_rewrite_regex"`
-	Id                         types.String      `tfsdk:"id"`
-	InheritanceParent          types.String      `tfsdk:"inheritance_parent"`
-	InheritanceSources         types.Object      `tfsdk:"inheritance_sources"`
-	Name                       types.String      `tfsdk:"name"`
-	Parent                     types.String      `tfsdk:"parent"`
-	Protocol                   types.String      `tfsdk:"protocol"`
-	Space                      types.String      `tfsdk:"space"`
-	Tags                       types.Map         `tfsdk:"tags"`
-	TagsAll                    types.Map         `tfsdk:"tags_all"`
-	Threshold                  types.Object      `tfsdk:"threshold"`
-	UpdatedAt                  timetypes.RFC3339 `tfsdk:"updated_at"`
-	Usage                      types.List        `tfsdk:"usage"`
-	Utilization                types.Object      `tfsdk:"utilization"`
-	UtilizationV6              types.Object      `tfsdk:"utilization_v6"`
-	NextAvailableId            types.String      `tfsdk:"next_available_id"`
+	Address                    types.String                     `tfsdk:"address"`
+	AsmConfig                  types.Object                     `tfsdk:"asm_config"`
+	AsmScopeFlag               types.Int64                      `tfsdk:"asm_scope_flag"`
+	Cidr                       types.Int64                      `tfsdk:"cidr"`
+	Comment                    types.String                     `tfsdk:"comment"`
+	CompartmentId              types.String                     `tfsdk:"compartment_id"`
+	CreatedAt                  timetypes.RFC3339                `tfsdk:"created_at"`
+	DdnsClientUpdate           types.String                     `tfsdk:"ddns_client_update"`
+	DdnsConflictResolutionMode types.String                     `tfsdk:"ddns_conflict_resolution_mode"`
+	DdnsDomain                 types.String                     `tfsdk:"ddns_domain"`
+	DdnsGenerateName           types.Bool                       `tfsdk:"ddns_generate_name"`
+	DdnsGeneratedPrefix        types.String                     `tfsdk:"ddns_generated_prefix"`
+	DdnsSendUpdates            types.Bool                       `tfsdk:"ddns_send_updates"`
+	DdnsTtlPercent             types.Float64                    `tfsdk:"ddns_ttl_percent"`
+	DdnsUpdateOnRenew          types.Bool                       `tfsdk:"ddns_update_on_renew"`
+	DdnsUseConflictResolution  types.Bool                       `tfsdk:"ddns_use_conflict_resolution"`
+	Delegation                 types.String                     `tfsdk:"delegation"`
+	DhcpConfig                 types.Object                     `tfsdk:"dhcp_config"`
+	DhcpOptions                types.List                       `tfsdk:"dhcp_options"`
+	DhcpUtilization            types.Object                     `tfsdk:"dhcp_utilization"`
+	DiscoveryAttrs             types.Map                        `tfsdk:"discovery_attrs"`
+	DiscoveryMetadata          types.Map                        `tfsdk:"discovery_metadata"`
+	ExternalKeys               types.Map                        `tfsdk:"external_keys"`
+	FederatedRealms            internaltypes.UnorderedListValue `tfsdk:"federated_realms"`
+	HeaderOptionFilename       types.String                     `tfsdk:"header_option_filename"`
+	HeaderOptionServerAddress  types.String                     `tfsdk:"header_option_server_address"`
+	HeaderOptionServerName     types.String                     `tfsdk:"header_option_server_name"`
+	HostnameRewriteChar        types.String                     `tfsdk:"hostname_rewrite_char"`
+	HostnameRewriteEnabled     types.Bool                       `tfsdk:"hostname_rewrite_enabled"`
+	HostnameRewriteRegex       types.String                     `tfsdk:"hostname_rewrite_regex"`
+	Id                         types.String                     `tfsdk:"id"`
+	InheritanceParent          types.String                     `tfsdk:"inheritance_parent"`
+	InheritanceSources         types.Object                     `tfsdk:"inheritance_sources"`
+	Name                       types.String                     `tfsdk:"name"`
+	Parent                     types.String                     `tfsdk:"parent"`
+	Protocol                   types.String                     `tfsdk:"protocol"`
+	Space                      types.String                     `tfsdk:"space"`
+	Tags                       types.Map                        `tfsdk:"tags"`
+	TagsAll                    types.Map                        `tfsdk:"tags_all"`
+	Threshold                  types.Object                     `tfsdk:"threshold"`
+	UpdatedAt                  timetypes.RFC3339                `tfsdk:"updated_at"`
+	Usage                      types.List                       `tfsdk:"usage"`
+	Utilization                types.Object                     `tfsdk:"utilization"`
+	UtilizationV6              types.Object                     `tfsdk:"utilization_v6"`
+	NextAvailableId            types.String                     `tfsdk:"next_available_id"`
 }
 
 var IpamsvcAddressBlockAttrTypes = map[string]attr.Type{
@@ -290,6 +291,7 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The external keys (source key) for this address block in JSON format.",
 	},
 	"federated_realms": schema.ListAttribute{
+		CustomType:          internaltypes.UnorderedListOfStringType,
 		ElementType:         types.StringType,
 		Optional:            true,
 		Computed:            true,
@@ -537,7 +539,7 @@ func (m *IpamsvcAddressBlockModel) Flatten(ctx context.Context, from *ipam.Addre
 	m.DiscoveryAttrs = flex.FlattenFrameworkMapString(ctx, from.DiscoveryAttrs, diags)
 	m.DiscoveryMetadata = flex.FlattenFrameworkMapString(ctx, from.DiscoveryMetadata, diags)
 	m.ExternalKeys = flex.FlattenFrameworkMapString(ctx, from.ExternalKeys, diags)
-	m.FederatedRealms = flex.FlattenFrameworkListStringNotNull(ctx, from.FederatedRealms, diags)
+	m.FederatedRealms = flex.FlattenFrameworkUnorderedListNotNull(ctx, types.StringType, from.FederatedRealms, diags)
 	m.HeaderOptionFilename = flex.FlattenStringPointer(from.HeaderOptionFilename)
 	m.HeaderOptionServerAddress = flex.FlattenStringPointer(from.HeaderOptionServerAddress)
 	m.HeaderOptionServerName = flex.FlattenStringPointer(from.HeaderOptionServerName)

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"context"
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
@@ -26,57 +27,57 @@ import (
 )
 
 type IpamsvcSubnetModel struct {
-	Address                    types.String      `tfsdk:"address"`
-	AsmConfig                  types.Object      `tfsdk:"asm_config"`
-	AsmScopeFlag               types.Int64       `tfsdk:"asm_scope_flag"`
-	Cidr                       types.Int64       `tfsdk:"cidr"`
-	Comment                    types.String      `tfsdk:"comment"`
-	CompartmentId              types.String      `tfsdk:"compartment_id"`
-	ConfigProfiles             types.List        `tfsdk:"config_profiles"`
-	CreatedAt                  timetypes.RFC3339 `tfsdk:"created_at"`
-	DdnsClientUpdate           types.String      `tfsdk:"ddns_client_update"`
-	DdnsConflictResolutionMode types.String      `tfsdk:"ddns_conflict_resolution_mode"`
-	DdnsDomain                 types.String      `tfsdk:"ddns_domain"`
-	DdnsGenerateName           types.Bool        `tfsdk:"ddns_generate_name"`
-	DdnsGeneratedPrefix        types.String      `tfsdk:"ddns_generated_prefix"`
-	DdnsSendUpdates            types.Bool        `tfsdk:"ddns_send_updates"`
-	DdnsTtlPercent             types.Float64     `tfsdk:"ddns_ttl_percent"`
-	DdnsUpdateOnRenew          types.Bool        `tfsdk:"ddns_update_on_renew"`
-	DdnsUseConflictResolution  types.Bool        `tfsdk:"ddns_use_conflict_resolution"`
-	Delegation                 types.String      `tfsdk:"delegation"`
-	DhcpConfig                 types.Object      `tfsdk:"dhcp_config"`
-	DhcpHost                   types.String      `tfsdk:"dhcp_host"`
-	DhcpOptions                types.List        `tfsdk:"dhcp_options"`
-	DhcpUtilization            types.Object      `tfsdk:"dhcp_utilization"`
-	DisableDhcp                types.Bool        `tfsdk:"disable_dhcp"`
-	DiscoveryAttrs             types.Map         `tfsdk:"discovery_attrs"`
-	DiscoveryMetadata          types.Map         `tfsdk:"discovery_metadata"`
-	ExternalKeys               types.Map         `tfsdk:"external_keys"`
-	FederatedRealms            types.List        `tfsdk:"federated_realms"`
-	HeaderOptionFilename       types.String      `tfsdk:"header_option_filename"`
-	HeaderOptionServerAddress  types.String      `tfsdk:"header_option_server_address"`
-	HeaderOptionServerName     types.String      `tfsdk:"header_option_server_name"`
-	HostnameRewriteChar        types.String      `tfsdk:"hostname_rewrite_char"`
-	HostnameRewriteEnabled     types.Bool        `tfsdk:"hostname_rewrite_enabled"`
-	HostnameRewriteRegex       types.String      `tfsdk:"hostname_rewrite_regex"`
-	Id                         types.String      `tfsdk:"id"`
-	InheritanceAssignedHosts   types.List        `tfsdk:"inheritance_assigned_hosts"`
-	InheritanceParent          types.String      `tfsdk:"inheritance_parent"`
-	InheritanceSources         types.Object      `tfsdk:"inheritance_sources"`
-	Name                       types.String      `tfsdk:"name"`
-	Parent                     types.String      `tfsdk:"parent"`
-	Protocol                   types.String      `tfsdk:"protocol"`
-	RebindTime                 types.Int64       `tfsdk:"rebind_time"`
-	RenewTime                  types.Int64       `tfsdk:"renew_time"`
-	Space                      types.String      `tfsdk:"space"`
-	Tags                       types.Map         `tfsdk:"tags"`
-	TagsAll                    types.Map         `tfsdk:"tags_all"`
-	Threshold                  types.Object      `tfsdk:"threshold"`
-	UpdatedAt                  timetypes.RFC3339 `tfsdk:"updated_at"`
-	Usage                      types.List        `tfsdk:"usage"`
-	Utilization                types.Object      `tfsdk:"utilization"`
-	UtilizationV6              types.Object      `tfsdk:"utilization_v6"`
-	NextAvailableId            types.String      `tfsdk:"next_available_id"`
+	Address                    types.String                     `tfsdk:"address"`
+	AsmConfig                  types.Object                     `tfsdk:"asm_config"`
+	AsmScopeFlag               types.Int64                      `tfsdk:"asm_scope_flag"`
+	Cidr                       types.Int64                      `tfsdk:"cidr"`
+	Comment                    types.String                     `tfsdk:"comment"`
+	CompartmentId              types.String                     `tfsdk:"compartment_id"`
+	ConfigProfiles             types.List                       `tfsdk:"config_profiles"`
+	CreatedAt                  timetypes.RFC3339                `tfsdk:"created_at"`
+	DdnsClientUpdate           types.String                     `tfsdk:"ddns_client_update"`
+	DdnsConflictResolutionMode types.String                     `tfsdk:"ddns_conflict_resolution_mode"`
+	DdnsDomain                 types.String                     `tfsdk:"ddns_domain"`
+	DdnsGenerateName           types.Bool                       `tfsdk:"ddns_generate_name"`
+	DdnsGeneratedPrefix        types.String                     `tfsdk:"ddns_generated_prefix"`
+	DdnsSendUpdates            types.Bool                       `tfsdk:"ddns_send_updates"`
+	DdnsTtlPercent             types.Float64                    `tfsdk:"ddns_ttl_percent"`
+	DdnsUpdateOnRenew          types.Bool                       `tfsdk:"ddns_update_on_renew"`
+	DdnsUseConflictResolution  types.Bool                       `tfsdk:"ddns_use_conflict_resolution"`
+	Delegation                 types.String                     `tfsdk:"delegation"`
+	DhcpConfig                 types.Object                     `tfsdk:"dhcp_config"`
+	DhcpHost                   types.String                     `tfsdk:"dhcp_host"`
+	DhcpOptions                types.List                       `tfsdk:"dhcp_options"`
+	DhcpUtilization            types.Object                     `tfsdk:"dhcp_utilization"`
+	DisableDhcp                types.Bool                       `tfsdk:"disable_dhcp"`
+	DiscoveryAttrs             types.Map                        `tfsdk:"discovery_attrs"`
+	DiscoveryMetadata          types.Map                        `tfsdk:"discovery_metadata"`
+	ExternalKeys               types.Map                        `tfsdk:"external_keys"`
+	FederatedRealms            internaltypes.UnorderedListValue `tfsdk:"federated_realms"`
+	HeaderOptionFilename       types.String                     `tfsdk:"header_option_filename"`
+	HeaderOptionServerAddress  types.String                     `tfsdk:"header_option_server_address"`
+	HeaderOptionServerName     types.String                     `tfsdk:"header_option_server_name"`
+	HostnameRewriteChar        types.String                     `tfsdk:"hostname_rewrite_char"`
+	HostnameRewriteEnabled     types.Bool                       `tfsdk:"hostname_rewrite_enabled"`
+	HostnameRewriteRegex       types.String                     `tfsdk:"hostname_rewrite_regex"`
+	Id                         types.String                     `tfsdk:"id"`
+	InheritanceAssignedHosts   types.List                       `tfsdk:"inheritance_assigned_hosts"`
+	InheritanceParent          types.String                     `tfsdk:"inheritance_parent"`
+	InheritanceSources         types.Object                     `tfsdk:"inheritance_sources"`
+	Name                       types.String                     `tfsdk:"name"`
+	Parent                     types.String                     `tfsdk:"parent"`
+	Protocol                   types.String                     `tfsdk:"protocol"`
+	RebindTime                 types.Int64                      `tfsdk:"rebind_time"`
+	RenewTime                  types.Int64                      `tfsdk:"renew_time"`
+	Space                      types.String                     `tfsdk:"space"`
+	Tags                       types.Map                        `tfsdk:"tags"`
+	TagsAll                    types.Map                        `tfsdk:"tags_all"`
+	Threshold                  types.Object                     `tfsdk:"threshold"`
+	UpdatedAt                  timetypes.RFC3339                `tfsdk:"updated_at"`
+	Usage                      types.List                       `tfsdk:"usage"`
+	Utilization                types.Object                     `tfsdk:"utilization"`
+	UtilizationV6              types.Object                     `tfsdk:"utilization_v6"`
+	NextAvailableId            types.String                     `tfsdk:"next_available_id"`
 }
 
 var IpamsvcSubnetAttrTypes = map[string]attr.Type{
@@ -106,31 +107,32 @@ var IpamsvcSubnetAttrTypes = map[string]attr.Type{
 	"discovery_attrs":               types.MapType{ElemType: types.StringType},
 	"discovery_metadata":            types.MapType{ElemType: types.StringType},
 	"external_keys":                 types.MapType{ElemType: types.StringType},
-	"federated_realms":              types.ListType{ElemType: types.StringType},
-	"header_option_filename":        types.StringType,
-	"header_option_server_address":  types.StringType,
-	"header_option_server_name":     types.StringType,
-	"hostname_rewrite_char":         types.StringType,
-	"hostname_rewrite_enabled":      types.BoolType,
-	"hostname_rewrite_regex":        types.StringType,
-	"id":                            types.StringType,
-	"inheritance_assigned_hosts":    types.ListType{ElemType: types.ObjectType{AttrTypes: InheritanceAssignedHostAttrTypes}},
-	"inheritance_parent":            types.StringType,
-	"inheritance_sources":           types.ObjectType{AttrTypes: IpamsvcDHCPInheritanceAttrTypes},
-	"name":                          types.StringType,
-	"parent":                        types.StringType,
-	"protocol":                      types.StringType,
-	"rebind_time":                   types.Int64Type,
-	"renew_time":                    types.Int64Type,
-	"space":                         types.StringType,
-	"tags":                          types.MapType{ElemType: types.StringType},
-	"tags_all":                      types.MapType{ElemType: types.StringType},
-	"threshold":                     types.ObjectType{AttrTypes: IpamsvcUtilizationThresholdAttrTypes},
-	"updated_at":                    timetypes.RFC3339Type{},
-	"usage":                         types.ListType{ElemType: types.StringType},
-	"utilization":                   types.ObjectType{AttrTypes: IpamsvcUtilizationAttrTypes},
-	"utilization_v6":                types.ObjectType{AttrTypes: IpamsvcUtilizationV6AttrTypes},
-	"next_available_id":             types.StringType,
+	//"federated_realms":              types.ListType{ElemType: types.StringType},
+	"federated_realms":             internaltypes.UnorderedListOfStringType,
+	"header_option_filename":       types.StringType,
+	"header_option_server_address": types.StringType,
+	"header_option_server_name":    types.StringType,
+	"hostname_rewrite_char":        types.StringType,
+	"hostname_rewrite_enabled":     types.BoolType,
+	"hostname_rewrite_regex":       types.StringType,
+	"id":                           types.StringType,
+	"inheritance_assigned_hosts":   types.ListType{ElemType: types.ObjectType{AttrTypes: InheritanceAssignedHostAttrTypes}},
+	"inheritance_parent":           types.StringType,
+	"inheritance_sources":          types.ObjectType{AttrTypes: IpamsvcDHCPInheritanceAttrTypes},
+	"name":                         types.StringType,
+	"parent":                       types.StringType,
+	"protocol":                     types.StringType,
+	"rebind_time":                  types.Int64Type,
+	"renew_time":                   types.Int64Type,
+	"space":                        types.StringType,
+	"tags":                         types.MapType{ElemType: types.StringType},
+	"tags_all":                     types.MapType{ElemType: types.StringType},
+	"threshold":                    types.ObjectType{AttrTypes: IpamsvcUtilizationThresholdAttrTypes},
+	"updated_at":                   timetypes.RFC3339Type{},
+	"usage":                        types.ListType{ElemType: types.StringType},
+	"utilization":                  types.ObjectType{AttrTypes: IpamsvcUtilizationAttrTypes},
+	"utilization_v6":               types.ObjectType{AttrTypes: IpamsvcUtilizationV6AttrTypes},
+	"next_available_id":            types.StringType,
 }
 
 var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
@@ -320,7 +322,8 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: "The external keys (source key) for this subnet in JSON format.",
 	},
 	"federated_realms": schema.ListAttribute{
-		ElementType:         types.StringType,
+		CustomType:          internaltypes.UnorderedListOfStringType,
+		ElementType:         types.StringType, //should this be removed ?
 		Optional:            true,
 		Computed:            true,
 		MarkdownDescription: "Federated realms to which this subnet belongs.",
@@ -571,7 +574,7 @@ func (m *IpamsvcSubnetModel) Flatten(ctx context.Context, from *ipam.Subnet, dia
 	m.DiscoveryAttrs = flex.FlattenFrameworkMapString(ctx, from.DiscoveryAttrs, diags)
 	m.DiscoveryMetadata = flex.FlattenFrameworkMapString(ctx, from.DiscoveryMetadata, diags)
 	m.ExternalKeys = flex.FlattenFrameworkMapString(ctx, from.ExternalKeys, diags)
-	m.FederatedRealms = flex.FlattenFrameworkListStringNotNull(ctx, from.FederatedRealms, diags)
+	m.FederatedRealms = flex.FlattenFrameworkUnorderedListNotNull(ctx, types.StringType, from.FederatedRealms, diags)
 	m.HeaderOptionFilename = flex.FlattenStringPointer(from.HeaderOptionFilename)
 	m.HeaderOptionServerAddress = flex.FlattenStringPointer(from.HeaderOptionServerAddress)
 	m.HeaderOptionServerName = flex.FlattenStringPointer(from.HeaderOptionServerName)


### PR DESCRIPTION
Subnet and address block, When more than 3 realms are assigned, it causes ordering issue, this PR addresses this 