### PR TITLE
Fix: change in bloxone_dns_view.name should not force replacement

### DIFF
--- a/internal/service/dns_config/api_view_resource_test.go
+++ b/internal/service/dns_config/api_view_resource_test.go
@@ -80,7 +80,6 @@ func TestAccViewResource_Name(t *testing.T) {
 	var name1 = acctest.RandomNameWithPrefix("view")
 	var name2 = acctest.RandomNameWithPrefix("view")
 	var v1 dnsconfig.View
-	var v2 dnsconfig.View
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -98,8 +97,7 @@ func TestAccViewResource_Name(t *testing.T) {
 			{
 				Config: testAccViewBasicConfig(name2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckViewDestroy(context.Background(), &v1),
-					testAccCheckViewExists(context.Background(), resourceName, &v2),
+					testAccCheckViewExists(context.Background(), resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
 				),
 			},

--- a/internal/service/dns_config/model_config_view.go
+++ b/internal/service/dns_config/model_config_view.go
@@ -362,10 +362,7 @@ var ConfigViewResourceSchemaAttributes = map[string]schema.Attribute{
 		MarkdownDescription: `Optional. When enabled, the DNS server will only add records to the authority and additional data sections when they are required.  Defaults to _false_.`,
 	},
 	"name": schema.StringAttribute{
-		Required: true,
-		PlanModifiers: []planmodifier.String{
-			stringplanmodifier.RequiresReplaceIfConfigured(),
-		},
+		Required:            true,
 		MarkdownDescription: `Name of view.`,
 	},
 	"notify": schema.BoolAttribute{


### PR DESCRIPTION
Currently changing view name forces replacement in the terraform module. This is allowed in API and UI, and hence there is no need to force a replacement