### PR TITLE
Restructured metadata to handle userdata and extend

### DIFF
--- a/modules/bloxone_infra_host_gcp/README.md
+++ b/modules/bloxone_infra_host_gcp/README.md
@@ -83,6 +83,7 @@ module "bloxone_infra_host_gcp" {
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | The size of the data disk in GB. | `number` | `59` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | The type of the data disk. | `string` | `"pd-standard"` | no |
 | <a name="input_gcp_instance_labels"></a> [gcp\_instance\_labels](#input\_gcp\_instance\_labels) | The labels to associate with the virtual machine. For `tags` to be used for the BloxOne Host, use the `tags` variable. | `map(string)` | `{}` | no |
+| <a name="input_gcp_disk_labels"></a> [gcp\_disk\_labels](#input\_gcp\_disk\_labels) | The labels to associate with the virtual machine disks. | `map(string)` | `{}` | no |
 | <a name="input_join_token"></a> [join\_token](#input\_join\_token) | The join token to use for the BloxOne Host. If not provided, a join token will be created. | `string` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to use for the virtual machine | `string` | `"e2-standard-4"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the virtual machine | `string` | n/a | yes |
@@ -93,6 +94,7 @@ module "bloxone_infra_host_gcp" {
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to use for the BloxOne Host. | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | The timeouts to use for the BloxOne Host. The timeout value is a string that can be parsed as a duration consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). If not provided, the default timeouts will be used. | <pre>object({<br/>    create = string<br/>    update = string<br/>    read   = string<br/>  })</pre> | `null` | no |
 | <a name="input_wait_for_state"></a> [wait\_for\_state](#input\_wait\_for\_state) | If set to `true`, the resource will wait for the desired state to be reached before returning. If set to `false`, the resource will return immediately after the request is sent to the API. | `bool` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | (Optional) The zone that the machine should be created in. If it is not provided, the provider zone is used. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/bloxone_infra_host_gcp/main.tf
+++ b/modules/bloxone_infra_host_gcp/main.tf
@@ -62,6 +62,15 @@ locals {
       "tf_module_host_id" = "bloxone-host-${random_uuid.this.result}"
     }
   )
+  metadata = merge(
+    var.metadata,
+    {
+      user-data = templatefile("${path.module}/userdata.tftpl", {
+        join_token = local.join_token
+        tags       = local.tags
+      })
+    }
+  )
 }
 
 resource "bloxone_infra_join_token" "this" {
@@ -74,13 +83,14 @@ resource "google_compute_instance" "this" {
   machine_type        = var.machine_type
   labels              = var.gcp_instance_labels
   deletion_protection = var.deletion_protection
+  zone                = var.zone
 
   boot_disk {
     initialize_params {
       image  = var.source_image
       type   = var.disk_type
       size   = var.disk_size
-      labels = var.gcp_instance_labels
+      labels = var.gcp_disk_labels
     }
   }
 
@@ -107,12 +117,7 @@ resource "google_compute_instance" "this" {
     }
   }
 
-  metadata = {
-    user-data = templatefile("${path.module}/userdata.tftpl", {
-      join_token = local.join_token
-      tags       = local.tags
-    })
-  }
+  metadata = local.metadata
 }
 
 data "bloxone_infra_hosts" "this" {

--- a/modules/bloxone_infra_host_gcp/variables.tf
+++ b/modules/bloxone_infra_host_gcp/variables.tf
@@ -15,6 +15,12 @@ variable "machine_type" {
   default     = "e2-standard-4"
 }
 
+variable "zone" {
+  description = "The zone for the solution to be deployed."
+  type        = string
+  default     = "us-east1-b"
+}
+
 variable "network_interfaces" {
   description = "List of network interfaces to be attached to the virtual machine."
   type = list(object({
@@ -47,8 +53,20 @@ variable "gcp_instance_labels" {
   default     = {}
 }
 
+variable "gcp_disk_labels" {
+  description = "The labels to associate with the virtual machine disk."
+  type        = map(string)
+  default     = {}
+}
+
 variable "tags" {
   description = "The tags to use for the BloxOne Host."
+  type        = map(string)
+  default     = {}
+}
+
+variable "metadata" {
+  description = "(Optional) Metadata key/value pairs to make available from within the VM instance."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
Now user can pass additional metadata to the vm

Add new variables zone and gcp_disk_lables