### PR TITLE
Added Acceptance Workflow for DDI object groups

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -31,4 +31,4 @@ jobs:
           DHCP_HOST: ${{ secrets.DHCP_HOST }}
           DNS_HOST: ${{ secrets.DNS_HOST }}
         run: |
-          go test $(go list ./... | grep -v 'vendor') -timeout 120m -v -cover
+          go test -parallel=1 $(go list ./... | grep -v 'vendor') -timeout 120m -v -cover

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -31,4 +31,4 @@ jobs:
           DHCP_HOST: ${{ secrets.DHCP_HOST }}
           DNS_HOST: ${{ secrets.DNS_HOST }}
         run: |
-          go test -parallel=1 $(go list ./... | grep -v 'vendor') -timeout 120m -v -cover
+          go test $(go list ./... | grep -v 'vendor') -timeout 120m -v -cover

--- a/.github/workflows/acceptance_test_ddi.yml
+++ b/.github/workflows/acceptance_test_ddi.yml
@@ -1,4 +1,4 @@
-name: Acceptance Tests for DDI objects
+name: Acceptance Tests for DDI object groups
 
 on:
   workflow_dispatch:

--- a/.github/workflows/acceptance_test_ddi.yml
+++ b/.github/workflows/acceptance_test_ddi.yml
@@ -1,4 +1,4 @@
-name: Acceptance Tests
+name: Acceptance Tests for DDI objects
 
 on:
   workflow_dispatch:

--- a/.github/workflows/acceptance_test_ddi.yml
+++ b/.github/workflows/acceptance_test_ddi.yml
@@ -1,0 +1,25 @@
+name: Acceptance Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-go@v5.2.0
+        with:
+          go-version: '1.23'
+      - name: Run tests
+        timeout-minutes: 120
+        env:
+          TF_ACC: "1"
+          BLOXONE_CSP_URL: ${{ secrets.BLOXONE_CSP_URL }}
+          BLOXONE_API_KEY: ${{ secrets.BLOXONE_API_KEY }}
+          DHCP_HOST: ${{ secrets.DHCP_HOST }}
+          DNS_HOST: ${{ secrets.DNS_HOST }}
+        run: |
+          go test -parallel=1 $(go list ./... | grep -E 'dns_config|dns_data|ipam|ipamfederation|clouddiscovery') -timeout 120m -v -cover


### PR DESCRIPTION
This PR contains an additional workflow to run the acceptance tests only on DDI objects