### PR TITLE
[ISSUE-259] Added `UseStateForUnknown` for attributes of certain IPAM objects

### DIFF
--- a/internal/service/ipam/model_ipamsvc_address.go
+++ b/internal/service/ipam/model_ipamsvc_address.go
@@ -84,6 +84,9 @@ var IpamsvcAddressResourceSchemaAttributes = map[string]schema.Attribute{
 		Validators: []validator.String{
 			stringvalidator.ExactlyOneOf(path.MatchRoot("address"), path.MatchRoot("next_available_id")),
 		},
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	},
 	"comment": schema.StringAttribute{
 		Optional:            true,

--- a/internal/service/ipam/model_ipamsvc_address_block.go
+++ b/internal/service/ipam/model_ipamsvc_address_block.go
@@ -132,6 +132,7 @@ var IpamsvcAddressBlockResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.RequiresReplaceIfConfigured(),
+			stringplanmodifier.UseStateForUnknown(),
 		},
 		MarkdownDescription: "The address field in form 'a.b.c.d'.",
 	},

--- a/internal/service/ipam/model_ipamsvc_fixed_address.go
+++ b/internal/service/ipam/model_ipamsvc_fixed_address.go
@@ -86,6 +86,7 @@ var IpamsvcFixedAddressResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.RequiresReplaceIfConfigured(),
+			stringplanmodifier.UseStateForUnknown(),
 		},
 		MarkdownDescription: "The reserved address.",
 	},

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -144,6 +144,7 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 		},
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.RequiresReplaceIfConfigured(),
+			stringplanmodifier.UseStateForUnknown(),
 		},
 	},
 	"asm_config": schema.SingleNestedAttribute{


### PR DESCRIPTION
## Summary
Certain computed (yet required) fields of IPAM objects have a tendency to go to `Unknown` ("known after apply") state while planning, even when other, unrelated attributes are modified — causing replacement in downstream objects. To avoid this, `UseStateForUnknown` is introduced so these attributes retain their pre-existing state value when not modified.

**Changes in this PR:**
- IPAM Address - `address`
- Subnet - `address`
- Address Block - `address`
- Fixed Address - `address`

## Type of Change
- [x] 🐛 Bug Fix
- [x] 🔧 Update Existing Schema or Model

## Affected Packages
- [x] `ipam`

**Resource / Data Source**: `bloxone_ipam_address`, `bloxone_ipam_subnet`, `bloxone_ipam_address_block`, `bloxone_ipam_fixed_address`
**Description**: Added `UseStateForUnknown` plan modifier to the `address` attribute on the above resources to prevent unnecessary "known after apply" plan diffs.

## Schema Changes
- [ ] New resource or data source added
- [ ] New attribute(s) added to existing resource
- [ ] Attribute(s) removed or renamed
- [ ] Required attributes changed
- [ ] Breaking change (requires state migration)

## Testing
- [ ] Unit tests added / updated
- [ ] Acceptance tests added / updated
- [x] Manually tested against a live environment

## Ticket / Issue
Fixes #259

## Changelog Inclusion
- [x] Consider for changelog and release notes addition

## Additional Context
None.
