### PR TITLE
Updated Github Workflows to use Go 1.25.1

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.2.0
         with:
-          go-version: '1.23'
+          go-version: '1.25.1'
       - name: Run tests
         timeout-minutes: 120
         env:

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -13,12 +13,13 @@ on:
     - 'examples/**'
 
 jobs:
-  build:
+  test-build:
     name: Build
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - uses: actions/checkout@v4.2.2
+      - uses: hashicorp/setup-terraform@v3.1.2
       - uses: actions/setup-go@v5.2.0
         with:
           go-version: '1.25.1'

--- a/.github/workflows/acceptance_test_ddi.yml
+++ b/.github/workflows/acceptance_test_ddi.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.2.0
         with:
-          go-version: '1.23'
+          go-version: '1.25.1'
       - name: Run tests
         timeout-minutes: 120
         env:

--- a/.github/workflows/acceptance_test_ddi.yml
+++ b/.github/workflows/acceptance_test_ddi.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test-build-ddi:
     name: Build
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - uses: actions/checkout@v4.2.2
+      - uses: hashicorp/setup-terraform@v3.1.2
       - uses: actions/setup-go@v5.2.0
         with:
           go-version: '1.25.1'

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-go@v5.5.0
         with:
-          go-version: "1.25"
+          go-version: "1.25.1"
       - uses: hashicorp/setup-terraform@v3.1.2
       - name: go mod
         run: |


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflows to use the built-in `setup-terraform` action and bumped Go version to 1.25.1.

## Type of Change
- [x] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [x] `docs` / GitHub workflows / modules (non-package changes)

**Resource / Data Source**: N/A (CI only)
**Description**: Updated `acceptance_test.yml`, `acceptance_test_ddi.yml`, and `pr-builder.yml` workflows.

## Schema Changes
- [ ] New resource or data source added
- [ ] New attribute(s) added to existing resource
- [ ] Attribute(s) removed or renamed
- [ ] Required attributes changed
- [ ] Breaking change (requires state migration)

## Testing
- [ ] Unit tests added / updated
- [ ] Acceptance tests added / updated
- [ ] Manually tested against a live environment

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [ ] Consider for changelog and release notes addition
<!-- Internal CI change only, no user-facing impact -->

## Additional Context
None.
