### PR TITLE
Fix DHCP inheritance update failure (400) and dhcp_options state drift in subnet/range

### DIFF
--- a/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
+++ b/internal/service/ipam/model_ipamsvc_inherited_dhcp_option.go
@@ -71,6 +71,7 @@ func (m *IpamsvcInheritedDHCPOptionModel) Expand(ctx context.Context, diags *dia
 	}
 	to := &ipam.InheritedDHCPOption{
 		Action: m.Action.ValueStringPointer(),
+		Value:  ExpandIpamsvcInheritedDHCPOptionItem(ctx, m.Value, diags),
 	}
 	return to
 }

--- a/internal/service/ipam/model_ipamsvc_range.go
+++ b/internal/service/ipam/model_ipamsvc_range.go
@@ -21,6 +21,7 @@ import (
 	"github.com/infobloxopen/bloxone-go-client/ipam"
 
 	"github.com/infobloxopen/terraform-provider-bloxone/internal/flex"
+	internaltypes "github.com/infobloxopen/terraform-provider-bloxone/internal/types"
 )
 
 type IpamsvcRangeModel struct {
@@ -28,7 +29,7 @@ type IpamsvcRangeModel struct {
 	CompartmentId            types.String      `tfsdk:"compartment_id"`
 	CreatedAt                timetypes.RFC3339 `tfsdk:"created_at"`
 	DhcpHost                 types.String      `tfsdk:"dhcp_host"`
-	DhcpOptions              types.List        `tfsdk:"dhcp_options"`
+	DhcpOptions              internaltypes.UnorderedListValue `tfsdk:"dhcp_options"`
 	DisableDhcp              types.Bool        `tfsdk:"disable_dhcp"`
 	End                      types.String      `tfsdk:"end"`
 	ExclusionRanges          types.List        `tfsdk:"exclusion_ranges"`
@@ -56,7 +57,7 @@ var IpamsvcRangeAttrTypes = map[string]attr.Type{
 	"compartment_id":             types.StringType,
 	"created_at":                 timetypes.RFC3339Type{},
 	"dhcp_host":                  types.StringType,
-	"dhcp_options":               types.ListType{ElemType: types.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}},
+	"dhcp_options":               internaltypes.UnorderedList{ListType: basetypes.ListType{ElemType: basetypes.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}}},
 	"disable_dhcp":               types.BoolType,
 	"end":                        types.StringType,
 	"exclusion_ranges":           types.ListType{ElemType: types.ObjectType{AttrTypes: IpamsvcExclusionRangeAttrTypes}},
@@ -107,6 +108,7 @@ var IpamsvcRangeResourceSchemaAttributes = map[string]schema.Attribute{
 			"Provide a resource ID to assign a specific DHCP host.",
 	},
 	"dhcp_options": schema.ListNestedAttribute{
+		CustomType: internaltypes.UnorderedList{ListType: basetypes.ListType{ElemType: basetypes.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}}},
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: IpamsvcOptionItemResourceSchemaAttributes,
 		},
@@ -292,7 +294,7 @@ func (m *IpamsvcRangeModel) Flatten(ctx context.Context, from *ipam.Range, diags
 	m.CompartmentId = flex.FlattenStringPointer(from.CompartmentId)
 	m.CreatedAt = timetypes.NewRFC3339TimePointerValue(from.CreatedAt)
 	m.DhcpHost = flex.FlattenStringPointerWithNilAsEmpty(from.DhcpHost)
-	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
+	m.DhcpOptions = flex.FlattenFrameworkUnorderedListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DisableDhcp = types.BoolPointerValue(from.DisableDhcp)
 	m.End = flex.FlattenString(from.End)
 	m.ExclusionRanges = flex.FlattenFrameworkListNestedBlock(ctx, from.ExclusionRanges, IpamsvcExclusionRangeAttrTypes, diags, FlattenIpamsvcExclusionRange)

--- a/internal/service/ipam/model_ipamsvc_subnet.go
+++ b/internal/service/ipam/model_ipamsvc_subnet.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/infobloxopen/bloxone-go-client/ipam"
 
@@ -47,7 +48,7 @@ type IpamsvcSubnetModel struct {
 	Delegation                 types.String                     `tfsdk:"delegation"`
 	DhcpConfig                 types.Object                     `tfsdk:"dhcp_config"`
 	DhcpHost                   types.String                     `tfsdk:"dhcp_host"`
-	DhcpOptions                types.List                       `tfsdk:"dhcp_options"`
+	DhcpOptions                internaltypes.UnorderedListValue `tfsdk:"dhcp_options"`
 	DhcpUtilization            types.Object                     `tfsdk:"dhcp_utilization"`
 	DisableDhcp                types.Bool                       `tfsdk:"disable_dhcp"`
 	DiscoveryAttrs             types.Map                        `tfsdk:"discovery_attrs"`
@@ -101,7 +102,7 @@ var IpamsvcSubnetAttrTypes = map[string]attr.Type{
 	"delegation":                    types.StringType,
 	"dhcp_config":                   types.ObjectType{AttrTypes: IpamsvcDHCPConfigAttrTypes},
 	"dhcp_host":                     types.StringType,
-	"dhcp_options":                  types.ListType{ElemType: types.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}},
+	"dhcp_options":                  internaltypes.UnorderedList{ListType: basetypes.ListType{ElemType: basetypes.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}}},
 	"dhcp_utilization":              types.ObjectType{AttrTypes: IpamsvcDHCPUtilizationAttrTypes},
 	"disable_dhcp":                  types.BoolType,
 	"discovery_attrs":               types.MapType{ElemType: types.StringType},
@@ -290,6 +291,7 @@ var IpamsvcSubnetResourceSchemaAttributes = map[string]schema.Attribute{
 			"Provide a resource ID to assign a specific DHCP host.",
 	},
 	"dhcp_options": schema.ListNestedAttribute{
+		CustomType: internaltypes.UnorderedList{ListType: basetypes.ListType{ElemType: basetypes.ObjectType{AttrTypes: IpamsvcOptionItemAttrTypes}}},
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: IpamsvcOptionItemResourceSchemaAttributes,
 		},
@@ -569,7 +571,7 @@ func (m *IpamsvcSubnetModel) Flatten(ctx context.Context, from *ipam.Subnet, dia
 	m.Delegation = flex.FlattenStringPointer(from.Delegation)
 	m.DhcpConfig = FlattenIpamsvcDHCPConfigForSubnetOrAddressBlock(ctx, from.DhcpConfig, diags)
 	m.DhcpHost = flex.FlattenStringPointerWithNilAsEmpty(from.DhcpHost)
-	m.DhcpOptions = flex.FlattenFrameworkListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
+	m.DhcpOptions = flex.FlattenFrameworkUnorderedListNestedBlock(ctx, from.DhcpOptions, IpamsvcOptionItemAttrTypes, diags, FlattenIpamsvcOptionItem)
 	m.DhcpUtilization = FlattenIpamsvcDHCPUtilization(ctx, from.DhcpUtilization, diags)
 	m.DisableDhcp = types.BoolPointerValue(from.DisableDhcp)
 	m.DiscoveryAttrs = flex.FlattenFrameworkMapString(ctx, from.DiscoveryAttrs, diags)


### PR DESCRIPTION
## Summary
Fixes two bugs in `bloxone_ipam_subnet` and `bloxone_ipam_range` when DHCP option inheritance is enabled on the parent address block (B1DDISPT-2545 / case 00666257).

**Bug 1 — Update fails with 400: `Option not set in 'InheritanceSources.DhcpOptions.Value.0.Value'`**
Root cause: `IpamsvcInheritedDHCPOptionModel.Expand()` was only sending `Action` in the PATCH payload and omitting `Value` entirely. The API expects each entry in `InheritanceSources.DhcpOptions.Value[n]` to include the full nested option item. On strict tenant configurations this is rejected with 400; on lenient ones the inherited values are silently wiped from state on every update.
Fix: Added `Value: ExpandIpamsvcInheritedDHCPOptionItem(ctx, m.Value, diags)` to the Expand function in `model_ipamsvc_inherited_dhcp_option.go`.

**Bug 2 — `Provider produced inconsistent result after apply` on create**
Root cause: `dhcp_options` used an ordered `types.List`. After create/update the API can return inherited and subnet-level options in a different order than configured (inherited options first), causing Terraform's post-apply consistency check to fail with an index mismatch.
Fix: Changed `DhcpOptions` from `types.List` to `internaltypes.UnorderedListValue` in both subnet and range models, following the same pattern already used for `federated_realms` and `anycast_config_refs`. This applies semantic equality that ignores element order.

**Reproduction** (on `https://csp.infoblox.com`, internal prod):
- Create address block with 2 DHCP options + `inheritance_sources.dhcp_options.action = "inherit"`
- Create subnet under it with `inheritance_sources.dhcp_options.action = "inherit"`
- Change only `name` on the subnet and re-apply
- Observed: all inherited `dhcp_options.value` entries dropped from state on every update (3 entries → null); on strict tenants, 400 Bad Request

## Type of Change
- [x] 🐛 Bug Fix

## Affected Packages
- [x] `ipam`

**Resource / Data Source**: `bloxone_ipam_subnet`, `bloxone_ipam_range`
**Description**: Fixed DHCP option inheritance update failure (400) and `dhcp_options` state drift on create.

## Schema Changes
- [ ] New resource or data source added
- [ ] New attribute(s) added to existing resource
- [ ] Attribute(s) removed or renamed
- [ ] Required attributes changed
- [ ] Breaking change (requires state migration)

## Testing
- [x] Unit tests added / updated
- [ ] Acceptance tests added / updated
- [x] Manually tested against a live environment

## Ticket / Issue
Fixes #263

## Changelog Inclusion
- [x] Consider for changelog and release notes addition

## Additional Context
Related internal tracking: B1DDISPT-2545 / case 00666257.
