### PR TITLE
update nios-x vm version to 4.1.10

### DIFF
--- a/modules/gcp-marketplace/nios-x-ui-tf/metadata.display.yaml
+++ b/modules/gcp-marketplace/nios-x-ui-tf/metadata.display.yaml
@@ -104,8 +104,8 @@ spec:
           xGoogleProperty:
             type: ET_GCE_DISK_IMAGE
           enumValueLabels:
-            - label: nios-x-virtual-server-4-0-0
-              value: projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-0-0
+            - label: nios-x-virtual-server-4-1-10
+              value: projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-1-10
         sub_networks:
           name: subnetworks
           title: Subnetwork name

--- a/modules/gcp-marketplace/nios-x-ui-tf/metadata.yaml
+++ b/modules/gcp-marketplace/nios-x-ui-tf/metadata.yaml
@@ -36,7 +36,7 @@ spec:
       - name: source_image
         description: The image name for the disk for the VM instance.
         varType: string
-        defaultValue: projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-0-0
+        defaultValue: projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-1-10
       - name: zone
         description: (Optional) The zone that the machine should be created in. If it is not provided, the provider zone is used.
         varType: string

--- a/modules/gcp-marketplace/nios-x-ui-tf/variables.tf
+++ b/modules/gcp-marketplace/nios-x-ui-tf/variables.tf
@@ -12,7 +12,7 @@ variable "goog_cm_deployment_name" {
 variable "source_image" {
   description = "The image name for the disk for the VM instance."
   type        = string
-  default     = "projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-0-0"
+  default     = "projects/infoblox-public-436917/global/images/nios-x-virtual-server-4-1-10"
 }
 
 variable "zone" {


### PR DESCRIPTION
## Summary
Updated NIOS-X VM version to 4.1.10 in the GCP Marketplace Terraform module.

## Type of Change
- [x] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [x] `docs` / GitHub workflows / modules (non-package changes)

**Resource / Data Source**: N/A (GCP Marketplace deployment module)
**Description**: Bumped NIOS-X VM version referenced in `modules/gcp-marketplace/nios-x-ui-tf`.

## Schema Changes
- [ ] New resource or data source added
- [ ] New attribute(s) added to existing resource
- [ ] Attribute(s) removed or renamed
- [ ] Required attributes changed
- [ ] Breaking change (requires state migration)

## Testing
- [ ] Unit tests added / updated
- [ ] Acceptance tests added / updated
- [x] Manually tested against a live environment

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [x] Consider for changelog and release notes addition

## Additional Context
None.
