### PR TITLE
Updated environment vars behaviour to be consistent with the update to `universal-ddi-go-client`

### DIFF
--- a/docs/guides/quickstart-dhcp.md
+++ b/docs/guides/quickstart-dhcp.md
@@ -35,7 +35,7 @@ provider "bloxone" {
 !> Warning: Hard-coded credentials are not recommended in any configuration file. It is recommended to use environment variables.
 
 You can also use the following environment variables to configure the provider:
-`BLOXONE_CSP_URL` and `BLOXONE_API_KEY`.
+`INFOBLOX_PORTAL_URL` and `INFOBLOX_PORTAL_KEY`. The `BLOXONE_CSP_URL` and `BLOXONE_API_KEY` environment variables are also supported as a deprecated fallback and will be removed in a future release.
 
 Initialize the provider by running the following command. This will download the provider and initialize the working directory.
 

--- a/docs/guides/quickstart-dns.md
+++ b/docs/guides/quickstart-dns.md
@@ -35,7 +35,7 @@ provider "bloxone" {
 !> Warning: Hard-coded credentials are not recommended in any configuration file. It is recommended to use environment variables.
 
 You can also use the following environment variables to configure the provider:
-`BLOXONE_CSP_URL` and `BLOXONE_API_KEY`.
+`INFOBLOX_PORTAL_URL` and `INFOBLOX_PORTAL_KEY`. The `BLOXONE_CSP_URL` and `BLOXONE_API_KEY` environment variables are also supported as a deprecated fallback and will be removed in a future release.
 
 Initialize the provider by running the following command. This will download the provider and initialize the working directory.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,6 @@ provider "bloxone" {
 
 ### Optional
 
-- `api_key` (String) API key for accessing the BloxOne API. Can also be configured by using the `BLOXONE_API_KEY` environment variable. https://docs.infoblox.com/space/BloxOneCloud/35430405/Configuring+User+API+Keys
-- `csp_url` (String) URL for BloxOne Cloud Services Portal. Can also be configured using the `BLOXONE_CSP_URL` environment variable.
+- `api_key` (String) API key for accessing the BloxOne API. Can also be configured by using the `INFOBLOX_PORTAL_KEY` environment variable. The `BLOXONE_API_KEY` environment variable is also supported as a deprecated fallback and will be removed in a future release. https://docs.infoblox.com/space/BloxOneCloud/35430405/Configuring+User+API+Keys
+- `csp_url` (String) URL for BloxOne Cloud Services Portal. Can also be configured using the `INFOBLOX_PORTAL_URL` environment variable. The `BLOXONE_CSP_URL` environment variable is also supported as a deprecated fallback and will be removed in a future release.
 - `default_tags` (Map of String) Tags to default for all resources.

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -58,7 +58,7 @@ func RandomName() string {
 // lookupEnvAny returns the value of the first set environment variable among names.
 func lookupEnvAny(names ...string) string {
 	for _, name := range names {
-		if v := os.Getenv(name); v != "" {
+		if v, ok := os.LookupEnv(name); ok {
 			return v
 		}
 	}
@@ -66,6 +66,8 @@ func lookupEnvAny(names ...string) string {
 }
 
 func PreCheck(t *testing.T) {
+	t.Helper()
+
 	cspURL := lookupEnvAny("INFOBLOX_PORTAL_URL", "BLOXONE_CSP_URL")
 	if cspURL == "" {
 		t.Fatal("INFOBLOX_PORTAL_URL (or the deprecated BLOXONE_CSP_URL) must be set for acceptance tests")

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -55,15 +55,25 @@ func RandomName() string {
 	return string(b)
 }
 
+// lookupEnvAny returns the value of the first set environment variable among names.
+func lookupEnvAny(names ...string) string {
+	for _, name := range names {
+		if v := os.Getenv(name); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func PreCheck(t *testing.T) {
-	cspURL := os.Getenv("BLOXONE_CSP_URL")
+	cspURL := lookupEnvAny("INFOBLOX_PORTAL_URL", "BLOXONE_CSP_URL")
 	if cspURL == "" {
-		t.Fatal("BLOXONE_CSP_URL must be set for acceptance tests")
+		t.Fatal("INFOBLOX_PORTAL_URL (or the deprecated BLOXONE_CSP_URL) must be set for acceptance tests")
 	}
 
-	apiKey := os.Getenv("BLOXONE_API_KEY")
+	apiKey := lookupEnvAny("INFOBLOX_PORTAL_KEY", "BLOXONE_API_KEY")
 	if apiKey == "" {
-		t.Fatal("BLOXONE_API_KEY must be set for acceptance tests")
+		t.Fatal("INFOBLOX_PORTAL_KEY (or the deprecated BLOXONE_API_KEY) must be set for acceptance tests")
 	}
 
 	BloxOneClient = universalddiclient.NewAPIClient(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -55,11 +55,11 @@ func (p *BloxOneProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 		Description: "The BloxOne provider is used to interact with the resources supported by Infoblox BloxOne API.",
 		Attributes: map[string]schema.Attribute{
 			"csp_url": schema.StringAttribute{
-				MarkdownDescription: "URL for BloxOne Cloud Services Portal. Can also be configured using the `BLOXONE_CSP_URL` environment variable.",
+				MarkdownDescription: "URL for BloxOne Cloud Services Portal. Can also be configured using the `INFOBLOX_PORTAL_URL` environment variable. The `BLOXONE_CSP_URL` environment variable is also supported as a deprecated fallback and will be removed in a future release.",
 				Optional:            true,
 			},
 			"api_key": schema.StringAttribute{
-				MarkdownDescription: "API key for accessing the BloxOne API. Can also be configured by using the `BLOXONE_API_KEY` environment variable. https://docs.infoblox.com/space/BloxOneCloud/35430405/Configuring+User+API+Keys",
+				MarkdownDescription: "API key for accessing the BloxOne API. Can also be configured by using the `INFOBLOX_PORTAL_KEY` environment variable. The `BLOXONE_API_KEY` environment variable is also supported as a deprecated fallback and will be removed in a future release. https://docs.infoblox.com/space/BloxOneCloud/35430405/Configuring+User+API+Keys",
 				Optional:            true,
 			},
 			"default_tags": schema.MapAttribute{

--- a/templates/guides/quickstart-dhcp.md
+++ b/templates/guides/quickstart-dhcp.md
@@ -35,7 +35,7 @@ provider "bloxone" {
 !> Warning: Hard-coded credentials are not recommended in any configuration file. It is recommended to use environment variables.
 
 You can also use the following environment variables to configure the provider:
-`BLOXONE_CSP_URL` and `BLOXONE_API_KEY`.
+`INFOBLOX_PORTAL_URL` and `INFOBLOX_PORTAL_KEY`. The `BLOXONE_CSP_URL` and `BLOXONE_API_KEY` environment variables are also supported as a deprecated fallback and will be removed in a future release.
 
 Initialize the provider by running the following command. This will download the provider and initialize the working directory.
 

--- a/templates/guides/quickstart-dns.md
+++ b/templates/guides/quickstart-dns.md
@@ -35,7 +35,7 @@ provider "bloxone" {
 !> Warning: Hard-coded credentials are not recommended in any configuration file. It is recommended to use environment variables.
 
 You can also use the following environment variables to configure the provider:
-`BLOXONE_CSP_URL` and `BLOXONE_API_KEY`.
+`INFOBLOX_PORTAL_URL` and `INFOBLOX_PORTAL_KEY`. The `BLOXONE_CSP_URL` and `BLOXONE_API_KEY` environment variables are also supported as a deprecated fallback and will be removed in a future release.
 
 Initialize the provider by running the following command. This will download the provider and initialize the working directory.
 


### PR DESCRIPTION
## Summary
Follows up on the migration to `universal-ddi-go-client` (#271), which renamed the provider's environment variables to `INFOBLOX_PORTAL_URL` / `INFOBLOX_PORTAL_KEY` while keeping `BLOXONE_CSP_URL` / `BLOXONE_API_KEY` as deprecated fallbacks at the SDK layer. This PR surfaces that behavior in the provider's own schema descriptions and docs, and fixes the acceptance test precheck, which only recognized the old, deprecated variable names.

## Type of Change
- [ ] 🆕 New Resource / Data Source
- [ ] 🔧 Update Existing Resource or Schema
- [x] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧹 Maintenance (dependency upgrades, CI, refactoring)

## Affected Packages
- [ ] `anycast`
- [ ] `clouddiscovery`
- [ ] `dfp`
- [ ] `dns_config`
- [ ] `dns_data`
- [ ] `fw`
- [ ] `infra_mgmt`
- [ ] `infra_provision`
- [ ] `ipam`
- [ ] `ipamfederation`
- [ ] `keys`
- [ ] `redirect`
- [x] `internal` / `provider` (core provider code)
- [x] `docs` / GitHub workflows / modules (non-package changes)

**Resource / Data Source**: N/A — provider-level configuration (`csp_url`, `api_key`)
**Description**: Documented `INFOBLOX_PORTAL_URL` / `INFOBLOX_PORTAL_KEY` as the primary environment variables (with `BLOXONE_CSP_URL` / `BLOXONE_API_KEY` noted as deprecated fallbacks) in the provider schema, generated docs, and quickstart guides; fixed `acctest.PreCheck` to recognize the new variable names instead of hard-failing when only they are set.

## Schema Changes
- [ ] New resource or data source added
- [ ] New attribute(s) added to existing resource
- [ ] Attribute(s) removed or renamed
- [ ] Required attributes changed
- [ ] Breaking change (requires state migration)

## Testing
- [ ] Unit tests added / updated
- [ ] Acceptance tests added / updated
- [ ] Manually tested against a live environment

## Ticket / Issue
Fixes #

## Changelog Inclusion
- [x] Consider for changelog and release notes addition

## Additional Context
The underlying `universal-ddi-go-client` SDK already resolves `INFOBLOX_PORTAL_URL`/`INFOBLOX_PORTAL_KEY` first and falls back to `BLOXONE_CSP_URL`/`BLOXONE_API_KEY` (see `internal/configuration.go` in the vendored client), so no functional change was required in `Configure()`. This PR only updates documentation/schema strings and the acceptance test precheck helper to match. Verified with `go build ./...` and `go vet`; docs regenerated via `tfplugindocs generate`.
